### PR TITLE
docs: Mermaid syntax incompatible with GitHub renderer in tls-mitm docs

### DIFF
--- a/docs/tls-mitm.md
+++ b/docs/tls-mitm.md
@@ -52,7 +52,7 @@ self-transition captures the key behaviour: multiple requests share one hijacked
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Received : CONNECT host:443
+    [*] --> Received
 
     Received --> MITMPath : AI domain + CA loaded
     Received --> OpaquePath : not AI domain


### PR DESCRIPTION
## Summary

Fixes Mermaid diagram rendering failures in `docs/tls-mitm.md` caused by syntax features unsupported by GitHub's Mermaid renderer.

## Changes

### `docs/tls-mitm.md`

**sequenceDiagram**
- Replaced `Note over C,P,API` (3 participants) with `Note over C,API` — GitHub Mermaid only supports `Note over` spanning at most 2 participants.

**stateDiagram-v2**
- Removed `<<choice>>` pseudo-states (`domainCheck`, `privateCheck`, `alpn`) and wired transitions directly between real states. GitHub's Mermaid renderer does not support `<<choice>>`.
- Removed the label on the `[*] --> Received` transition — `[*]` transitions with labels are unsupported in GitHub Mermaid `stateDiagram-v2`.

## Type

- [x] Documentation
- [ ] Bug fix
- [ ] Feature