### PR TITLE
add SonarQube integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ ai-domains.json
 # Environment overrides (may contain secrets)
 .env
 .env.local
+
+# SonarQube
+sonar-project.properties
+coverage.out
+.scannerwork/
+golangci-report.xml
+test-report.xml

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,18 @@ vulncheck:
 check: lint test security vulncheck
 	@echo "All checks passed."
 
+sonar: ## Run full analysis and push to SonarQube
+	@echo "--- Generating coverage report ---"
+	$(GO) test ./... -coverprofile=coverage.out
+	@echo "--- Generating test report ---"
+	$(GO) test ./... -v -json | go-junit-report -set-exit-code > test-report.xml
+	@echo "--- Generating golangci-lint report ---"
+	golangci-lint run --output.checkstyle.path golangci-report.xml ./... || true
+	@echo "--- Running sonar-scanner ---"
+	sonar-scanner
+	@echo "--- Cleaning up ---"
+	rm -f coverage.out test-report.xml golangci-report.xml
+
 clean:
 	rm -rf bin/
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,6 +90,16 @@ make vulncheck     # Go vulnerability database check
 make check         # lint + test + security + vulncheck
 ```
 
+## Static analysis (SonarQube)
+
+Requires `sonar-scanner` and `go-junit-report` on `$PATH`, and a local SonarQube instance
+(see `infra/sonarqube/`). Create `sonar-project.properties` in the project root (gitignored)
+with your token and run:
+
+```bash
+make sonar
+```
+
 ## Smoke test (requires running proxy)
 
 ```bash


### PR DESCRIPTION
## chore: add SonarQube integration

Sets up local SonarQube (Community Edition) static analysis for the project.

### Changes

**Makefile**
- Add `sonar` target that orchestrates the full analysis pipeline: coverage report, JUnit test report, golangci-lint checkstyle report, and sonar-scanner invocation. Cleans up generated artifacts after the scan.

**.gitignore**
- Exclude `sonar-project.properties` (contains auth token)
- Exclude generated report artifacts (`coverage.out`, `golangci-report.xml`, `test-report.xml`)
- Exclude `.scannerwork/` scanner cache directory

### Notes
- `sonar-project.properties` is not committed — see developer docs for setup instructions
- Requires `sonar-scanner` and `go-junit-report` to be installed locally