### PR TITLE
chore(repo): gitignore .claude/, CLAUDE.md, and .tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,13 @@ logs/
 # Serena
 .serena/
 
+# Claude Code agent instructions (dev tooling, not product code)
+.claude/
+CLAUDE.md
+
+# Temporary make outputs (benchmarks, coverage scratch, intermediate files)
+.tmp/
+
 # Runtime state
 ai-domains.json
 


### PR DESCRIPTION
## What

Adds three gitignore entries to keep development tooling and transient outputs out of the public repository.

## Changes

- `.gitignore` — adds `.claude/` (Claude Code agent instructions), `CLAUDE.md` (entry point), and `.tmp/` (scratch directory for benchmark outputs and transient make artifacts)

## Quality Gates

- [x] `make check` passed — 0 issues, all tests green, gosec clean, no vulnerabilities
- [x] No source code changes — gitignore only
- [x] Coverage: unchanged

## Test Plan

- `git check-ignore -v .claude/` — confirms ignored
- `git check-ignore -v CLAUDE.md` — confirms ignored
- `git check-ignore -v .tmp/` — confirms ignored

## SonarQube

Not applicable — no source changes.

## Linked Issues

None.