### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs for supply chain security [closes #19]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.10.1
           args: --timeout=5m
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -77,10 +77,10 @@ jobs:
     needs: [lint, test, security]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -89,7 +89,7 @@ jobs:
         run: go build -ldflags="-s -w" -o bin/proxy ./cmd/proxy
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: proxy-binary
           path: bin/proxy


### PR DESCRIPTION
## What

Pin all third-party GitHub Actions in `.github/workflows/ci.yml` to their full commit SHAs to prevent supply chain attacks via tag mutation. Actions pinned to tags (e.g., `actions/checkout@v4`) are vulnerable to tag mutation — a compromised tag can inject malicious code into CI. SHA pinning is the industry standard for supply chain security.

## Changes

- `.github/workflows/ci.yml`:
  - Pin `actions/checkout` to SHA with version comment
  - Pin `actions/setup-go` to SHA with version comment
  - Pin `golangci/golangci-lint-action` to SHA with version comment
  - Pin `actions/upload-artifact` to SHA with version comment

## Supply Chain

| Action | Old Reference | New SHA | Version |
|--------|---------------|---------|---------|
| `actions/checkout` | `@v4` | `08eba0b27e820071cde6df949e0beb9ba4906955` | v4.3.0 |
| `actions/setup-go` | `@v5` | `d35c59abb061a4a6fb18e82ac0862c26744d6ab5` | v5.5.0 |
| `golangci/golangci-lint-action` | `@v7` | `9fae48acfc02a90574d7c304a1758ef9895495fa` | v7.0.1 |
| `actions/upload-artifact` | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |

## Quality Gates

- [x] `make check` passed — `All checks passed.`
- [x] No source code changes — CI workflow only
- [x] All SHAs verified against expected tags on GitHub
- [x] Permissions unchanged — `contents: read` maintained
- [x] Job structure unchanged — Lint → Test → Security → Build

## Test Plan

- CI will run on this PR branch with the new pinned SHAs
- All four jobs (Lint, Test, Security, Build) should pass
- No functional changes to the codebase — purely CI hardening

## Linked Issues

Closes #19