### PR TITLE
chore(config): extract duplicate privacy tokens strings to constants [closes #29]

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,15 @@ import (
 	"strconv"
 )
 
+// piiInstructionPrefix is the common prefix for all PII instruction strings.
+const piiInstructionPrefix = "PRIVACY TOKENS: This request contains privacy-preserving placeholders" +
+	" matching the pattern [PII_XXXXXXXX] (8 hex characters). "
+
+// piiInstructionDefault is the standard PII instruction used for models without a
+// specialized instruction (gpt, default, and other non-Claude models).
+const piiInstructionDefault = piiInstructionPrefix +
+	"Reproduce every such token verbatim in your response. Do not substitute them with example values."
+
 // Config holds the full proxy configuration.
 type Config struct {
 	ProxyPort           int     `json:"proxyPort"`
@@ -84,17 +93,12 @@ func defaults() *Config {
 			"/v1/auth", "/api/auth", "/api/login", "/api/token",
 		},
 		PIIInstructions: map[string]string{
-			"claude": "PRIVACY TOKENS: This request contains privacy-preserving placeholders" +
-				" matching the pattern [PII_XXXXXXXX] (8 hex characters). You MUST reproduce" +
-				" every such token EXACTLY as written in your response. Do NOT replace them with" +
+			"claude": piiInstructionPrefix +
+				"You MUST reproduce every such token EXACTLY as written in your response. Do NOT replace them with" +
 				" example values, email addresses, phone numbers, names, or any other substitutes." +
 				" Treat [PII_*] tokens as opaque identifiers that must pass through unchanged.",
-			"gpt": "PRIVACY TOKENS: This request contains privacy-preserving placeholders" +
-				" matching the pattern [PII_XXXXXXXX] (8 hex characters). Reproduce every such" +
-				" token verbatim in your response. Do not substitute them with example values.",
-			"default": "PRIVACY TOKENS: This request contains privacy-preserving placeholders" +
-				" matching the pattern [PII_XXXXXXXX] (8 hex characters). Reproduce every such" +
-				" token verbatim in your response. Do not substitute them with example values.",
+			"gpt":     piiInstructionDefault,
+			"default": piiInstructionDefault,
 		},
 	}
 }


### PR DESCRIPTION
## What

Extracts duplicate privacy tokens instruction strings in `internal/config/config.go` to named constants to resolve SonarQube maintainability findings. No behaviour change.

## Changes

- `internal/config/config.go`:
  - Added `piiInstructionPrefix` constant for the common prefix shared by all PII instructions
  - Added `piiInstructionDefault` constant for the standard instruction used by "gpt" and "default"
  - Updated `PIIInstructions` map in `defaults()` to use the constants
  - "claude" instruction now uses `piiInstructionPrefix` + its unique suffix
  - "gpt" and "default" now reference `piiInstructionDefault` directly

## Quality Gates

- [x] `make check` passed: `All checks passed.`
- [ ] `make sonar` — N/A: `sonar-project.properties` is gitignored; cannot run in worktree
- [x] Coverage: No change (refactor only, no new code paths)
- [ ] All CI jobs green (Lint / Test / Security / Build / Benchmark)
- [x] Architecture invariants maintained (see CLAUDE.md)
- [x] No new gosec findings outside existing exclusions

## Test Plan

- Existing unit tests pass — the refactor is purely mechanical string extraction
- `make check` passes all linting, tests, gosec, and govulncheck

## SonarQube

N/A — `sonar-project.properties` is gitignored and not available in worktree. Last known clean run on main.

## Linked Issues

Closes #29