### PR TITLE
refactor(anonymizer): reduce tokenForMatch cognitive complexity [closes #31]

### DIFF
--- a/internal/anonymizer/anonymizer.go
+++ b/internal/anonymizer/anonymizer.go
@@ -281,18 +281,27 @@ func (a *Anonymizer) tokenForMatch(p pattern, match string) string {
 
 	// Low-confidence path: check persistent per-value cache.
 	if cached, hit := a.cache.Get(match); hit {
-		if a.m != nil {
-			a.m.RecordCacheHit(string(p.piiType))
-		}
-		return cached
+		return a.handleCacheHit(p.piiType, cached)
 	}
 
-	// Cache miss: apply fallback token immediately so PII is never unmasked,
-	// then dispatch Ollama async to warm the cache.
-	token := a.replacement(p.piiType, match)
-	log.Printf("[ANONYMIZER] low-confidence cache miss piiType=%s", p.piiType)
+	return a.handleCacheMiss(p.piiType, match)
+}
+
+// handleCacheHit records metrics and returns the cached token.
+func (a *Anonymizer) handleCacheHit(piiType PIIType, cached string) string {
 	if a.m != nil {
-		a.m.RecordCacheMiss(string(p.piiType))
+		a.m.RecordCacheHit(string(piiType))
+	}
+	return cached
+}
+
+// handleCacheMiss generates a fallback token, logs the miss, records metrics,
+// and dispatches an async Ollama query to warm the cache.
+func (a *Anonymizer) handleCacheMiss(piiType PIIType, match string) string {
+	token := a.replacement(piiType, match)
+	log.Printf("[ANONYMIZER] low-confidence cache miss piiType=%s", piiType)
+	if a.m != nil {
+		a.m.RecordCacheMiss(string(piiType))
 		a.m.CacheFallbacks.Add(1)
 	}
 	a.dispatchOllamaAsync(match)

--- a/internal/anonymizer/anonymizer_test.go
+++ b/internal/anonymizer/anonymizer_test.go
@@ -244,6 +244,65 @@ func TestLowConfidenceCacheHit(t *testing.T) {
 	}
 }
 
+// TestLowConfidenceCacheHitWithMetrics verifies that cache hit metrics are
+// recorded when the metrics collector is present.
+func TestLowConfidenceCacheHitWithMetrics(t *testing.T) {
+	m := metrics.New()
+
+	// First pass to discover the exact regex match.
+	discovery := New("http://localhost:11434", "test-model", false, 0.80, 1, nil)
+	input := "555-867-5309 is my number"
+	discovery.AnonymizeText(input, "discover")
+	discovery.sessionMu.RLock()
+	var matchedValue string
+	for _, orig := range discovery.sessions["discover"] {
+		matchedValue = orig
+		break
+	}
+	discovery.sessionMu.RUnlock()
+	if matchedValue == "" {
+		t.Fatal("discovery pass produced no session mappings")
+	}
+
+	// Now test cache hit with metrics.
+	a := New("http://localhost:11434", "test-model", true, 0.80, 1, m)
+	a.cache.Set(matchedValue, "[PII_cached01]")
+
+	a.AnonymizeText(input, "sess-metrics-hit")
+
+	snap := m.Snapshot()
+	totalHits := int64(0)
+	for _, v := range snap.PIITokens.CacheHits {
+		totalHits += v
+	}
+	if totalHits == 0 {
+		t.Error("expected CacheHits > 0 after cache hit with metrics")
+	}
+}
+
+// TestLowConfidenceCacheMissWithMetrics verifies that cache miss metrics are
+// recorded when the metrics collector is present.
+func TestLowConfidenceCacheMissWithMetrics(t *testing.T) {
+	m := metrics.New()
+	a := New("http://localhost:11434", "test-model", true, 0.80, 1, m)
+
+	// Phone has confidence 0.65, below the 0.80 threshold — triggers cache miss.
+	input := "555-867-5309 is my number"
+	a.AnonymizeText(input, "sess-metrics-miss")
+
+	snap := m.Snapshot()
+	totalMisses := int64(0)
+	for _, v := range snap.PIITokens.CacheMisses {
+		totalMisses += v
+	}
+	if totalMisses == 0 {
+		t.Error("expected CacheMisses > 0 after cache miss with metrics")
+	}
+	if snap.PIITokens.CacheFallbacks == 0 {
+		t.Error("expected CacheFallbacks > 0 after cache miss with metrics")
+	}
+}
+
 // TestOllamaCacheKeyedByValue verifies that the same PII value appearing in
 // two different messages produces the same token — proving the cache is keyed
 // by value, not by surrounding text. Uses useAI=false (high-confidence email)


### PR DESCRIPTION
## What

Reduces the cognitive complexity of `tokenForMatch` by extracting helper functions as suggested in the issue. The refactor decomposes the function into:
- `tokenForMatch` - thin coordinator that handles high-confidence path and delegates low-confidence paths
- `handleCacheHit` - records metrics and returns the cached token
- `handleCacheMiss` - generates fallback token, logs, records metrics, and dispatches async Ollama

## Changes

- `internal/anonymizer/anonymizer.go`:
  - Extracted `handleCacheHit` helper function
  - Extracted `handleCacheMiss` helper function
  - Simplified `tokenForMatch` to delegate to helpers

- `internal/anonymizer/anonymizer_test.go`:
  - Added `TestLowConfidenceCacheHitWithMetrics` - exercises cache hit path with metrics enabled
  - Added `TestLowConfidenceCacheMissWithMetrics` - exercises cache miss path with metrics enabled

## Quality Gates

- [x] `make check` passed: `All checks passed.`
- [ ] `make sonar` — N/A: `sonar-project.properties` is gitignored; cannot run in worktree
- [x] Coverage: 71.0% → 72.4% (improved)
- [ ] All CI jobs green (Lint / Test / Security / Build / Benchmark)
- [x] Architecture invariants maintained (see CLAUDE.md)
- [x] No new gosec findings outside existing exclusions

## Test Plan

**Before refactor:**
```
go test -race -coverprofile=coverage-before.out ./internal/anonymizer/...
ok  	ai-anonymizing-proxy/internal/anonymizer	1.873s	coverage: 71.0% of statements
```

**After refactor (with new tests):**
```
go test -race -coverprofile=coverage-final.out ./internal/anonymizer/...
ok  	ai-anonymizing-proxy/internal/anonymizer	1.708s	coverage: 72.4% of statements
```

**Coverage of refactored functions:**
```
tokenForMatch    100.0%
handleCacheHit   100.0%
handleCacheMiss  100.0%
```

Coverage increased because the new tests exercise the metrics recording paths in `handleCacheHit` and `handleCacheMiss` that were previously uncovered when existing tests passed `nil` for metrics.

## SonarQube

N/A — `sonar-project.properties` is gitignored and not available in worktree. Last known clean run on main.

## Linked Issues

Closes #31