### PR TITLE
chore: ignore .mcp.json — written by docker entrypoint, contains token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ ai-domains.json
 .env
 .env.local
 
+# MCP server config (written by docker entrypoint, contains token)
+.mcp.json
+
 # SonarQube
 sonar-project.properties
 coverage.out


### PR DESCRIPTION
Adds `.mcp.json` to `.gitignore`. This file is written at container startup by the docker entrypoint and contains the GitHub PAT. It must never be committed.