### PR TITLE
docs(anonymizer): update docs for StreamingDeanonymize decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ curl http://localhost:8081/metrics
   proxy is restarted. The cert cache is capped at 10 000 entries and is cleared in full when the
   limit is reached.
 - **Streaming responses use on-the-fly de-anonymization.** SSE / chunked responses are never
-  fully buffered; a sliding window approach replaces tokens as data flows through, with a 64-byte
-  overlap to prevent tokens from straddling chunk boundaries.
+  fully buffered; text is accumulated across consecutive `text_delta` events and flushed only
+  when a 26-byte suffix guard confirms no partial token straddles the boundary.
 - **Management API authentication is optional.** Set `MANAGEMENT_TOKEN` to require bearer token
   auth. Without it, anyone with network access to port 8081 can add or remove domains.
 

--- a/docs/anonymizer.md
+++ b/docs/anonymizer.md
@@ -160,17 +160,31 @@ token like `[PII_EMAIL_c160f8cc]` frequently arrives split across multiple event
 {"type":"text_delta","text":"IL_c160f8cc]"}
 ```
 
-Raw byte replacement cannot match tokens split this way. `StreamingDeanonymize` handles this by:
+Raw byte replacement cannot match tokens split this way. `StreamingDeanonymize` delegates to a
+pipeline of small helper functions (in `streaming.go`) that each handle one concern:
 
-1. Buffering incoming bytes line by line.
-2. Parsing each `data: {...}` SSE line as JSON.
-3. Accumulating text content across consecutive `content_block_delta` / `text_delta` **and**
-   `thinking_delta` events.
-4. Flushing only the prefix that cannot be the start of a pending token. A `tokenSuffixLen` of
-   26 bytes is retained in the accumulator — enough to cover the longest possible token
+1. **Line assembly** (`readLoop` → `assembleLines`) — reads raw bytes from the source, splits
+   on newlines, strips `\r`, and dispatches complete lines.
+2. **Line classification** (`processLine`) — routes each SSE line: comments and empty lines
+   pass through verbatim; non-`data:` lines go through the replacer; `data:` lines are parsed
+   as JSON.
+3. **Text accumulation** (`processTextDelta`) — accumulates text across consecutive
+   `content_block_delta` / `text_delta` **and** `thinking_delta` events, tracks the content
+   block index, and flushes safe prefixes.
+4. **Safe flush boundary** (`safeCutPoint`) — calculates how many accumulated bytes can be
+   flushed without splitting a partial token. A `tokenSuffixLen` of 26 bytes is retained in
+   the accumulator — enough to cover the longest possible token
    (`[PII_CREDITCARD_XXXXXXXX]` = 25 chars).
-5. Applying the replacer to **all** passthrough paths (non-JSON lines, non-delta events, etc.)
-   so tokens embedded anywhere in the SSE stream are deanonymized.
+5. **Remainder flush** (`flushRemainder`) — when a non-text-delta event arrives or the stream
+   ends, any text still in the accumulator is emitted as a synthetic `content_block_delta`
+   targeting the correct content block index.
+6. **Stream end** (`handleStreamEnd`) — flushes partial lines and accumulated text at EOF or on
+   read error.
+
+A `streamContext` struct holds the shared mutable state for a single invocation: the pipe
+writer, replacer, text accumulator, last-seen content block index, and logging configuration.
+The replacer is applied on **all** passthrough paths (non-JSON lines, non-delta events, etc.)
+so tokens embedded anywhere in the SSE stream are deanonymized.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,12 +219,29 @@ Each request gets a random `sessionID`. The token→original map is stored in
 For SSE (`Content-Type: text/event-stream`), `StreamingDeanonymize` wraps the response body in a
 pipe-based reader. Because the Anthropic API delivers one or two characters per `text_delta`
 event, a single token like `[PII_EMAIL_c160f8cc]` frequently arrives split across multiple
-events. The reader therefore accumulates text across consecutive `content_block_delta` /
-`text_delta` and `thinking_delta` events, flushing only the prefix that cannot be the start of
-a pending token. A `tokenSuffixLen` of 26 bytes is retained in the accumulator — enough to
-cover the longest possible token (`[PII_CREDITCARD_XXXXXXXX]` = 25 chars). Non-delta events
-(ping, message_start, etc.) also pass through the replacer so tokens embedded in any part of
-the SSE stream are deanonymized.
+events.
+
+The streaming logic is decomposed into small, independently testable helpers in
+`internal/anonymizer/streaming.go`:
+
+| Helper | Responsibility |
+|---|---|
+| `readLoop` | Top-level goroutine: reads chunks from the source and dispatches complete lines |
+| `assembleLines` | Splits raw bytes on newlines, strips `\r`, dispatches to `processLine` |
+| `processLine` | Classifies each SSE line (comment, non-data, JSON data) and routes accordingly |
+| `processTextDelta` | Accumulates text across `text_delta` / `thinking_delta` events, flushes safe prefixes |
+| `safeCutPoint` | Calculates how many accumulated bytes can be flushed without splitting a partial token |
+| `flushRemainder` | Emits a synthetic `content_block_delta` carrying any text still in the accumulator |
+| `handleStreamEnd` | Flushes partial lines and accumulated text at EOF or on read error |
+
+A `streamContext` struct holds the mutable state shared across these helpers for a single
+streaming invocation, including the `lastIndex` field that tracks the most recently seen
+content block index so that flush events target the correct block (thinking vs. text).
+
+The 26-byte suffix guard (`tokenSuffixLen`) is retained in the accumulator — enough to cover
+the longest possible token (`[PII_CREDITCARD_XXXXXXXX]` = 25 chars). Non-delta events (ping,
+message_start, etc.) also pass through the replacer so tokens embedded in any part of the SSE
+stream are deanonymized.
 
 ## SSRF protection
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,7 +129,12 @@ ai-proxy/
 ├── internal/
 │   ├── anonymizer/
 │   │   ├── anonymizer.go          # Two-stage PII detection (regex + Ollama) and de-anonymization
-│   │   └── anonymizer_test.go
+│   │   ├── anonymizer_test.go
+│   │   ├── streaming.go           # Streaming SSE deanonymization helpers (decomposed pipeline)
+│   │   ├── streaming_test.go
+│   │   ├── cache.go               # PersistentCache interface, memoryCache, bboltCache
+│   │   ├── s3fifo_cache.go        # S3-FIFO in-memory eviction layer wrapping bboltCache
+│   │   └── s3fifo_cache_test.go
 │   ├── config/
 │   │   ├── config.go              # Config loading: defaults → proxy-config.json → env vars
 │   │   └── config_test.go
@@ -183,8 +188,10 @@ returned IPs against private/loopback/link-local CIDRs before completing the TCP
 closes the TOCTOU gap that exists when IP checks are done at request-parse time but the
 connection is established later.
 
-**Streaming de-anonymization.** SSE responses are never fully buffered. A pipe-based reader
-accumulates text across `text_delta` and `thinking_delta` events and flushes only the prefix
-that cannot be the start of a pending token (`tokenSuffixLen` = 26 bytes), ensuring tokens
-cannot straddle a chunk boundary regardless of upstream framing. See
-[anonymizer.md](anonymizer.md) for the full strategy.
+**Streaming de-anonymization.** SSE responses are never fully buffered. The streaming pipeline
+in `streaming.go` is decomposed into small helpers (`readLoop`, `assembleLines`, `processLine`,
+`processTextDelta`, `safeCutPoint`, `flushRemainder`, `handleStreamEnd`) sharing a
+`streamContext` struct. Text is accumulated across `text_delta` and `thinking_delta` events and
+flushed only when a 26-byte suffix guard (`tokenSuffixLen`) confirms no partial token straddles
+the boundary. The context tracks the last-seen content block index so flush events target the
+correct block. See [anonymizer.md](anonymizer.md) for the full strategy.


### PR DESCRIPTION
## What

Updates all documentation to reflect the streaming deanonymization refactoring from PR #51 (issue #34). The monolithic `StreamingDeanonymize` function was decomposed into a pipeline of small helpers in `streaming.go` — the docs now describe this architecture accurately.

## Changes

- **README.md** — fixed the "Known Limitations" streaming entry: corrected "64-byte overlap" to "26-byte suffix guard" and replaced "sliding window" with accurate accumulation description
- **docs/architecture.md** — expanded "De-anonymization and streaming" section with a table of all helper functions, their responsibilities, and the `streamContext` struct with `lastIndex` tracking
- **docs/anonymizer.md** — rewrote "Streaming deanonymization" section to describe the decomposed six-step pipeline instead of the old monolithic approach
- **docs/development.md** — added `streaming.go`, `streaming_test.go`, `cache.go`, `s3fifo_cache.go`, and `s3fifo_cache_test.go` to the project structure listing; updated the streaming design decision to reference the decomposed helpers

## Quality Gates

- [x] No source code changed — docs only
- [x] `go test ./...` passes (no regressions from doc-only changes)
- [x] All links within docs remain valid (cross-references to anonymizer.md intact)
- [x] No implementation details exposed that belong in private docs — helper names and struct fields are public-facing descriptions of the architecture

## Test Plan

Docs-only PR — no functional changes. Verified all tests pass to confirm no accidental source modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)