### PR TITLE
docs: add GLOBAL, US, FR pack test set docs to docs/test-plans/

### DIFF
--- a/docs/test-plans/fr-pack-testset.md
+++ b/docs/test-plans/fr-pack-testset.md
@@ -1,0 +1,97 @@
+# FR Pack Test Set
+
+Use these messages to test FR pack PII detection through the proxy. Each contains synthetic but **checksum-valid** PII.
+
+> **Changelog (v2):** All NIR values now have correct mod-97 keys. All SIRET/SIREN
+> values are Luhn-valid. Negative test extension number uses a non-Luhn, non-9-digit
+> value to avoid SIREN and SSN cross-matches. SIRET phone-like edge case uses standard
+> 3+3+3+5 grouping. DE test values unchanged (space-formatting is a pre-existing DE
+> pack gap — DE Steuer-ID, SVNR will fail until DE pack gets space-tolerant regexes).
+
+> **Test config:** `EnabledPacks: ["GLOBAL", "US", "DE", "FR", "SECRETS"]`, `UseAI: false`, `PackDecayRate: 0.0`
+
+---
+
+## NIR (Numéro d'Inscription au Répertoire) — Social Security
+
+### Should detect
+
+"Bonjour, je vous envoie mon numéro de sécurité sociale pour le dossier: 1 85 12 75 108 042 79. Merci de le traiter en urgence."
+
+"Le patient masculin né en mars 1990 en Corse-du-Sud porte le NIR 1 90 03 2A 014 012 75 et doit être enregistré dans le système."
+
+"Pour la déclaration, mon numéro est 2 78 06 99 341 002 50. Pouvez-vous vérifier?"
+
+### NIR with Corsica department codes (2A/2B)
+
+"NIR du résident corse: 1 90 03 2A 014 012 75"
+"Autre résident: 2 87 11 2B 033 001 59"
+
+---
+
+## SIRET (14 digits — SIREN + NIC)
+
+### Should detect
+
+"Veuillez envoyer la facture à notre entreprise, SIRET 362 521 874 00036, pour le traitement comptable."
+
+"Le prestataire a le numéro SIRET 443 061 841 00013, basé à Lyon."
+
+### SIRET that looks like a phone number
+
+"Contact: 362 521 874 00036 — this should be detected as SIRET, not phone."
+
+---
+
+## SIREN (9 digits)
+
+### Should detect
+
+"L'entreprise est immatriculée sous le SIREN 362 521 874 au registre du commerce."
+
+"Vérifiez le SIREN 443 061 841 dans la base SIRENE avant de procéder."
+
+---
+
+## Mixed content — FR and DE in one message
+
+"Unsere französische Niederlassung (SIRET 362 521 874 00036) hat einen neuen Mitarbeiter eingestellt. Seine Steuer-ID ist 65 929 970 489 und seine französische Sozialversicherungsnummer lautet 1 85 12 75 108 042 79. Bitte alles im HR-System erfassen."
+
+---
+
+## Multiple PII types in one sentence
+
+"Le contrat réf. SIREN 362 521 874 concerne M. Dupont, NIR 1 85 12 75 108 042 79, domicilié au 15 rue de la Paix, 75002 Paris."
+
+---
+
+## Negative tests — should NOT trigger
+
+"The reference number is 12345678901 and the order total is 362.52."
+
+"Please call us at extension 44306183 for more information."
+
+"Meeting scheduled for 1 85 12 at conference room 042 on the 36th floor."
+
+---
+
+## Checksum verification reference
+
+### NIR (mod 97): key = 97 - (base13 % 97)
+
+| Description | Base (13 digits) | Key | Full NIR |
+|---|---|---|---|
+| Male, Dec 1985, dept 75 | 1851275108042 | 79 | 1 85 12 75 108 042 79 |
+| Male, Mar 1990, Corsica 2A (sub 19) | 1900319014012 | 75 | 1 90 03 2A 014 012 75 |
+| Female, Jun 1978, dept 99 | 2780699341002 | 50 | 2 78 06 99 341 002 50 |
+| Female, Nov 1987, Corsica 2B (sub 18) | 2871118033001 | 59 | 2 87 11 2B 033 001 59 |
+
+### SIRET/SIREN (Luhn algorithm)
+
+| Type | Value | Luhn valid |
+|---|---|---|
+| SIREN | 362 521 874 | Yes |
+| SIREN | 443 061 841 | Yes |
+| SIRET | 362 521 874 00036 | Yes |
+| SIRET | 443 061 841 00013 | Yes |
+| Negative (extension) | 44306183 (8 digits) | No (and not 9 digits, avoids SSN) |

--- a/docs/test-plans/global-pack-testset.md
+++ b/docs/test-plans/global-pack-testset.md
@@ -1,0 +1,143 @@
+# GLOBAL Pack Test Set
+
+Use these messages to test GLOBAL + US pack PII detection through the proxy. All checksum values are computed programmatically.
+
+> **Test config:** `EnabledPacks: ["GLOBAL", "US", "DE", "FR", "SECRETS"]`, `UseAI: false`, `PackDecayRate: 0.0`
+
+---
+
+## Email
+
+### Should detect
+
+"Contact: alice@example.com for info."
+
+"Send to user.name+tag@domain.co.uk please."
+
+"Email: test@sub.domain.org."
+
+"Input .user@example.com here."
+> Note: regex skips the leading dot, matches "user@example.com". Validator passes because local part is clean.
+
+### Should NOT detect
+
+"Bad: user..name@example.com."
+> Validator rejects consecutive dots in local part (RFC 5321).
+
+"Not an email: just-a-string."
+> No @ symbol -- regex does not match.
+
+---
+
+## API Key
+
+### Should detect
+
+"Config: api_key=abc123def456ghi789jklmno set."
+
+"Header: token: sk-abc123def456ghi789jklmno sent."
+
+`Use secret="xxxxxxxxxxxxxxxxxxxxxxxx" in config.`
+
+"Auth: bearer XYZabc123def456ghi789jk applied."
+
+### Should NOT detect
+
+"Set api_key=abc in config."
+> Token < 20 chars. Regex `[a-zA-Z0-9_\-.]{20,}` rejects.
+
+"Value randomlongstringwithoutprefix123 here."
+> No keyword prefix (api_key, token, secret, bearer).
+
+---
+
+## Credit Card (Luhn validated)
+
+### Should detect
+
+"Card: 4111111111111111 on file."
+> Visa, 16 digits, Luhn valid.
+
+"Card: 4111 1111 1111 1111 on file."
+> Same, spaced format.
+
+"Card: 4111-1111-1111-1111 on file."
+> Same, dashed format.
+
+"Card: 5500000000000004 saved."
+> Mastercard, 16 digits, Luhn valid.
+
+"Amex: 378282246310005 on file."
+> American Express, 15 digits, Luhn valid.
+
+### Should NOT detect
+
+"Card: 1234567890123456 fake."
+> 16 digits but Luhn check fails.
+
+"Number 123456789012 short."
+> 12 digits -- below 13-digit minimum.
+
+---
+
+## Cross-pattern interference tests
+
+"Number 362521874 in the system."
+> 9 digits, Luhn-valid. SIREN pattern claims it (registered first). SSN regex also matches (area 362 is valid), but SIREN replacement already consumed the match.
+
+"Number 362521879 in file."
+> 9 digits, Luhn-invalid. SIREN validator rejects. SSN regex then matches (area 362 is valid, group 52, serial 1879 all non-zero). Detected as SSN -- cross-pattern leakage.
+
+"Call 555-123-4567 for support."
+> US phone format. Detected as PHONE.
+
+"Code 12345 ist falsch."
+> FINDING: US address regex `(?i)\d+\s+[A-Za-z\s]+St\b` matches "12345 ist" because German "ist" decomposes as "i" + "St" suffix. Detected as ADDRESS. This is a false positive when processing German text.
+
+---
+
+## Negatives -- should NOT trigger
+
+"The weather today looks good."
+> Plain text, no PII patterns.
+
+"Running v1.234.567.8901 release."
+> Version string. US phone validator rejects dot-only separators.
+
+---
+
+## Edge cases
+
+### Multiple GLOBAL types in one message
+
+"Email alice@example.com, card 4111111111111111, key api_key=abc123def456ghi789jklmno."
+> Should detect: EMAIL + CREDITCARD + APIKEY
+
+### Email adjacent to URL
+
+"Visit https://site.com or email admin@site.com."
+> Should detect: EMAIL (admin@site.com). URL is not a PII pattern.
+
+---
+
+## Checksum verification reference
+
+### Credit Card (Luhn algorithm)
+
+| Type | Number | Luhn valid |
+|---|---|---|
+| Visa | 4111111111111111 | Yes |
+| Mastercard | 5500000000000004 | Yes |
+| Amex | 378282246310005 | Yes |
+| Invalid | 1234567890123456 | No |
+
+### Cross-pattern SIREN/SSN overlap
+
+| Value | SIREN Luhn | SSN area valid | Claimed by |
+|---|---|---|---|
+| 362521874 | Yes | Yes (362) | SIREN (runs first) |
+| 362521879 | No | Yes (362) | SSN (SIREN validator rejects) |
+
+## Test results (verified against commit f2fb6ea)
+
+**27 passed, 0 warned, 0 failed out of 27**

--- a/docs/test-plans/us-pack-testset.md
+++ b/docs/test-plans/us-pack-testset.md
@@ -1,0 +1,191 @@
+# US Pack Test Set
+
+Use these messages to test US pack PII detection through the proxy. Covers all 6 US patterns: SSN, Phone, Address, IPv4, IPv6, ZIP.
+
+> **Test config:** `EnabledPacks: ["GLOBAL", "US", "DE", "FR", "SECRETS"]`, `UseAI: false`, `PackDecayRate: 0.0`
+
+---
+
+## 1. SSN (Social Security Number -- 9 digits, area code validation)
+
+### 1.1 Should detect
+
+"My SSN is 123-45-6789."
+> Hyphenated format. Area 123 valid, group 45 valid, serial 6789 valid.
+
+"SSN: 123456789 on file."
+> Contiguous 9 digits. Same value, no hyphens.
+
+"SSN 001-01-0001 is the lowest valid."
+> Area 001 is the lowest valid area code.
+
+"SSN 899-99-9999 is highest before invalid range."
+> Area 899 is the last valid area code before the 900+ exclusion.
+
+### 1.2 Should NOT detect (validator rejects)
+
+"SSN 000-12-3456 rejected."
+> Area 000 has never been issued.
+
+"SSN 666-12-3456 rejected."
+> Area 666 has never been issued.
+
+"SSN 900-12-3456 rejected."
+> Area >= 900 has never been issued.
+
+"SSN 999-99-9999 rejected."
+> Area 999 in the excluded range.
+
+"SSN 123-00-6789 rejected."
+> Group 00 has never been issued.
+
+"SSN 123-45-0000 rejected."
+> Serial 0000 has never been issued.
+
+---
+
+## 2. Phone (US format -- NANPA, requires non-dot separator)
+
+### 2.1 Should detect
+
+"Call 555-867-5309 for info."
+> Hyphenated format.
+
+"Phone: (212) 555-0100."
+> Parenthesized area code.
+
+"Reach us at +1-800-555-1234."
+> With +1 country code.
+
+"Number: 555 867 5309 available."
+> Space-separated format.
+
+### 2.2 Should NOT detect (validator rejects)
+
+"Version 555.867.5309 released."
+> Dot-only separators rejected by validator (looks like version string).
+
+"Dial 5558675309 now."
+> Pure digits with no separator -- too ambiguous, validator rejects.
+
+---
+
+## 3. Address (US street format -- requires street type suffix)
+
+### 3.1 Should detect
+
+"Lives at 123 Main Street in town."
+
+"Office at 456 Elm Ave downtown."
+
+"Located at 789 Oak Boulevard."
+
+"Turn onto 100 Pine Road ahead."
+
+"Delivery to 42 Maple Lane."
+
+"Meet at 555 Cedar Drive."
+
+"Parked near 10 Birch Court."
+
+"Ship to 321 Oak St please."
+> Abbreviated suffix "St".
+
+### 3.2 Known false positive
+
+"Code 12345 ist falsch."
+> KNOWN BUG (#68): German "ist" matches as "i" + "St" suffix. US address regex `(?i)\d+\s+[A-Za-z\s]+St\b` triggers.
+
+---
+
+## 4. IPv4 (dotted quad notation)
+
+### 4.1 Should detect
+
+"Server at 192.168.1.1 running."
+> Private network (RFC 1918).
+
+"Bind to 127.0.0.1 for local."
+> Loopback address.
+
+"DNS: 8.8.8.8 configured."
+> Google public DNS.
+
+"Broadcast 255.255.255.255 sent."
+> Broadcast address.
+
+---
+
+## 5. IPv6 (RFC 5952 all forms)
+
+### 5.1 Should detect
+
+"Host: 2001:0db8:85a3:0000:0000:8a2e:0370:7334."
+> Full uncompressed form.
+
+"Loopback: ::1 configured."
+> Compressed loopback.
+
+"Interface fe80:: detected."
+> Link-local prefix.
+
+"Address 2001:db8::1 in use."
+> Compressed with zero omission.
+
+---
+
+## 6. ZIP Code (5 digits, optional +4)
+
+### 6.1 Should detect
+
+"Ship to 90210 please."
+> 5-digit ZIP. Maps to ADDRESS type. Confidence 0.40 (very low).
+
+"ZIP: 90210-1234 on label."
+> ZIP+4 format.
+
+---
+
+## 7. Negatives -- should NOT trigger
+
+"The quick brown fox jumps."
+> Plain text, no PII.
+
+"Running v2.345.678.9012 build."
+> Version string. Phone validator rejects dot-only separators.
+
+"Order 42 confirmed."
+> Too few digits for any US pattern.
+
+"Ref number 12345678 noted."
+> 8 digits. Not 9 (SSN), not 5 (ZIP), no phone separators.
+
+---
+
+## 8. Edge cases
+
+### 8.1 SSN + Phone in one message
+
+"SSN 123-45-6789, phone 555-867-5309."
+> Both detected: PII_SSN + PII_PHONE.
+
+### 8.2 Address + ZIP in one sentence
+
+"Lives at 123 Main Street, 90210."
+> Both detected as PII_ADDRESS (address pattern + ZIP pattern).
+
+### 8.3 IPv4 + IPv6 together
+
+"Hosts: 192.168.1.1 and 2001:db8::1."
+> Both detected as PII_IPADDRESS.
+
+### 8.4 All US types in one message
+
+"SSN 123-45-6789, phone (212) 555-0100, 123 Main Street, 90210, server 192.168.1.1."
+> Should detect: SSN + PHONE + ADDRESS + ADDRESS(ZIP) + IPADDRESS.
+
+---
+
+## 9. Test results (verified against commit f2fb6ea)
+
+43 passed, 0 warned, 0 failed out of 43


### PR DESCRIPTION
## Summary

Add missing per-pack test set documentation to `docs/test-plans/` so they are accessible to Claude Code remote sessions (`.idea/` is gitignored and unavailable in cloud environments).

## Files added

- `docs/test-plans/global-pack-testset.md` — GLOBAL pack (email, API key, credit card) + cross-pattern interference tests
- `docs/test-plans/us-pack-testset.md` — US pack (SSN, phone, address, IPv4, IPv6, ZIP) with 43 test cases
- `docs/test-plans/fr-pack-testset.md` — FR pack (NIR, SIRET, SIREN) with checksum-valid synthetic data

These complement the existing test plan docs committed in PR #71 (DE, NL, FINANCE_EU, HEALTHCARE, multilang integration, test method).

## No code changes