### PR TITLE
fix(ci): redirect benchmark stderr to prevent output interleaving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           mkdir -p .tmp
           go test -run='^$' -bench=. -benchmem -benchtime=1s -count=1 \
-            ./internal/anonymizer/... | tee .tmp/benchmark-ci.txt
+            ./internal/anonymizer/... 2>.tmp/benchmark-stderr.txt | tee .tmp/benchmark-ci.txt
 
       - name: Check benchmark thresholds
         run: |


### PR DESCRIPTION
Go benchmark output (stdout) was interleaved with anonymizer log lines (stderr), causing benchmark names and ns/op values to land on separate lines. The regex parsers in the threshold check, PR comment script, and badge update script expect both on a single line — so streaming benchmarks were silently skipped, resulting in `0ns / 20ms` in the streaming badge.

**Fix:** redirect stderr to `.tmp/benchmark-stderr.txt` before piping stdout to `tee`.

**One line changed** in `.github/workflows/ci.yml`.