### PR TITLE
chore: add LICENSE, CONTRIBUTING, coverage badge, and repo topics

### DIFF
--- a/.github/scripts/update-coverage-gist.sh
+++ b/.github/scripts/update-coverage-gist.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# update-coverage-gist.sh — update shields.io coverage badge data in a GitHub gist
+#
+# Usage: update-coverage-gist.sh <coverage-file> <gist-id>
+# Requires: BENCHMARK_GIST_TOKEN env var (PAT with gist scope)
+
+COVERAGE_FILE="${1:?ERROR: coverage file required as first argument}"
+GIST_ID="${2:?ERROR: gist ID required as second argument}"
+
+if [ ! -f "$COVERAGE_FILE" ]; then
+  echo "ERROR: coverage file not found: $COVERAGE_FILE" >&2
+  exit 1
+fi
+
+if [ -z "${BENCHMARK_GIST_TOKEN:-}" ]; then
+  echo "ERROR: BENCHMARK_GIST_TOKEN not set" >&2
+  exit 1
+fi
+
+# Extract total coverage percentage from go tool cover -func output
+# Last line is: total:  (statements)  XX.X%
+COVERAGE=$(go tool cover -func="$COVERAGE_FILE" | grep '^total:' | awk '{print $NF}' | tr -d '%')
+
+if [ -z "$COVERAGE" ]; then
+  echo "ERROR: could not parse coverage from $COVERAGE_FILE" >&2
+  exit 1
+fi
+
+# Determine badge color
+# green >= 85, yellow >= 70, red < 70
+COLOR="red"
+if [ "$(echo "$COVERAGE >= 85" | bc -l)" -eq 1 ]; then
+  COLOR="brightgreen"
+elif [ "$(echo "$COVERAGE >= 70" | bc -l)" -eq 1 ]; then
+  COLOR="yellow"
+fi
+
+DISPLAY="${COVERAGE}%"
+
+# Build gist payload
+PAYLOAD=$(cat << JSONEOF
+{
+  "files": {
+    "coverage.json": {
+      "content": "{ \"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"${DISPLAY}\", \"color\": \"${COLOR}\" }"
+    }
+  }
+}
+JSONEOF
+)
+
+# Update gist via GitHub API
+curl -sf -X PATCH \
+  -H "Authorization: token ${BENCHMARK_GIST_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -d "$PAYLOAD" \
+  "https://api.github.com/gists/${GIST_ID}" > /dev/null
+
+echo "Gist ${GIST_ID} updated: coverage=${DISPLAY} (${COLOR})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Display coverage
         run: go tool cover -func=coverage.out
 
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          BENCHMARK_GIST_TOKEN: ${{ secrets.BENCHMARK_GIST_TOKEN }}
+        run: |
+          bash .github/scripts/update-coverage-gist.sh coverage.out 0fcf197a0e717817dbeb34d146db423e
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for your interest in contributing to the AI Anonymizing Proxy.
+
+## Getting started
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Run the full check suite: `make check`
+5. Open a pull request against `main`
+
+## Development workflow
+
+Build, test, lint, and security scanning instructions are in
+[docs/development.md](docs/development.md). The key commands:
+
+```bash
+make build       # compile
+make check       # lint + test + security + vulncheck (must pass before PR)
+go test -race ./...  # race detector
+```
+
+## Code quality
+
+- All code must pass `golangci-lint` with the project's `.golangci.yml` configuration
+- Tests must accompany new functionality
+- Coverage must stay above 85% overall
+- Security-sensitive paths require 100% coverage
+
+## Adding PII detection patterns
+
+New patterns go in `internal/anonymizer/packs/`. Each pack is a self-contained
+file that self-registers via `init()`. Every pattern must include a source comment
+linking to the specification or reference it was derived from. See existing packs
+for the expected structure.
+
+Test sets for each pack are documented in `docs/test-plans/`.
+
+## Reporting issues
+
+Use GitHub Issues. If reporting a false positive or false negative in PII detection,
+include a minimal reproduction string (with synthetic data, never real PII).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 laplaque
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/laplaque/ai-anonymizing-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/laplaque/ai-anonymizing-proxy/actions/workflows/ci.yml)
 [![regex / cache](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/laplaque/0fcf197a0e717817dbeb34d146db423e/raw/benchmark-regex-cache.json)](https://github.com/laplaque/ai-anonymizing-proxy/actions/workflows/ci.yml)
 [![streaming](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/laplaque/0fcf197a0e717817dbeb34d146db423e/raw/benchmark-streaming.json)](https://github.com/laplaque/ai-anonymizing-proxy/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/laplaque/0fcf197a0e717817dbeb34d146db423e/raw/coverage.json)](https://github.com/laplaque/ai-anonymizing-proxy/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Privacy-preserving infrastructure for AI-assisted development.
 


### PR DESCRIPTION
## Summary

Community readiness improvements — adds the practical signals that indicate a healthy open-source project.

## Changes

- **LICENSE** — MIT
- **CONTRIBUTING.md** — points to `docs/development.md` for workflow, covers fork/branch/PR conventions, pack contribution guidance, and issue reporting
- **Coverage badge** — shields.io endpoint badge via the same gist used for benchmark badges. CI `test` job updates the gist on push to `main`. Thresholds: green ≥85%, yellow ≥70%, red <70%
- **License badge** — static MIT badge in README
- **Repo topics** — `privacy`, `proxy`, `pii`, `gdpr`, `golang`, `llm`, `anonymization`, `mitm-proxy`, `ai-security`, `self-hosted`

## Notes

- Topics are already applied (they're a repo setting, not a file)
- Coverage badge will show "not found" until the first push to `main` populates the gist with `coverage.json`
- Reuses `BENCHMARK_GIST_TOKEN` secret — no new secrets needed
