### PR TITLE
Add comprehensive test coverage for proxy and MITM components

### DIFF
--- a/.github/scripts/delta-coverage.sh
+++ b/.github/scripts/delta-coverage.sh
@@ -29,6 +29,8 @@ fi
 
 echo "=== Delta Coverage Check (threshold: ${THRESHOLD}%) ==="
 echo ""
+changed_files_count=$(echo "$changed_files" | wc -l)
+
 echo "Changed source files:"
 echo "$changed_files" | sed 's/^/  /'
 echo ""
@@ -40,9 +42,8 @@ failed=0
 checked=0
 
 while IFS= read -r file; do
-  # go tool cover uses module-relative paths; strip the leading directory
-  # to match against the file paths from git diff.
-  # The cover output format is: <module-path>/<file>:<line>:\t<func>\t<coverage>
+  # Match file path precisely using literal match with trailing colon
+  # to prevent substring collisions (e.g. proxy.go matching reverse_proxy.go).
   while IFS= read -r line; do
     # Extract coverage percentage (last field, strip %)
     pct=$(echo "$line" | awk '{print $NF}' | tr -d '%')
@@ -61,11 +62,11 @@ while IFS= read -r file; do
       echo "FAIL: ${line}"
       failed=$((failed + 1))
     fi
-  done < <(echo "$cover_output" | grep "$file" || true)
+  done < <(echo "$cover_output" | grep -F "/$file:" || true)
 done <<< "$changed_files"
 
 echo ""
-echo "Checked ${checked} functions in ${changed_files_count:=$(echo "$changed_files" | wc -l)} changed files."
+echo "Checked ${checked} functions in ${changed_files_count} changed files."
 
 if [ "$failed" -gt 0 ]; then
   echo "ERROR: ${failed} function(s) below ${THRESHOLD}% coverage threshold."

--- a/.github/scripts/delta-coverage.sh
+++ b/.github/scripts/delta-coverage.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# delta-coverage.sh — fail if any function in changed .go files is below threshold
+#
+# Usage: delta-coverage.sh <coverage-profile> <threshold> <base-ref>
+# Example: delta-coverage.sh coverage.out 95.0 origin/main
+
+COVERAGE_FILE="${1:?ERROR: coverage profile required as first argument}"
+THRESHOLD="${2:?ERROR: threshold percentage required as second argument}"
+BASE_REF="${3:?ERROR: base ref required as third argument}"
+
+if [ ! -f "$COVERAGE_FILE" ]; then
+  echo "ERROR: coverage file not found: $COVERAGE_FILE" >&2
+  exit 1
+fi
+
+# Get changed .go source files (exclude tests, generated, mocks)
+changed_files=$(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD" -- '*.go' \
+  | grep -v '_test\.go$' \
+  | grep -v '_generated\.go$' \
+  | grep -v 'mock_' \
+  || true)
+
+if [ -z "$changed_files" ]; then
+  echo "No changed Go source files — delta coverage check skipped."
+  exit 0
+fi
+
+echo "=== Delta Coverage Check (threshold: ${THRESHOLD}%) ==="
+echo ""
+echo "Changed source files:"
+echo "$changed_files" | sed 's/^/  /'
+echo ""
+
+# Get function-level coverage
+cover_output=$(go tool cover -func="$COVERAGE_FILE")
+
+failed=0
+checked=0
+
+while IFS= read -r file; do
+  # go tool cover uses module-relative paths; strip the leading directory
+  # to match against the file paths from git diff.
+  # The cover output format is: <module-path>/<file>:<line>:\t<func>\t<coverage>
+  while IFS= read -r line; do
+    # Extract coverage percentage (last field, strip %)
+    pct=$(echo "$line" | awk '{print $NF}' | tr -d '%')
+    func_name=$(echo "$line" | awk '{print $(NF-1)}')
+
+    # Skip the total line
+    if [ "$func_name" = "(statements)" ]; then
+      continue
+    fi
+
+    checked=$((checked + 1))
+
+    # Compare using awk for float comparison
+    below=$(awk "BEGIN {print ($pct < $THRESHOLD) ? 1 : 0}")
+    if [ "$below" -eq 1 ]; then
+      echo "FAIL: ${line}"
+      failed=$((failed + 1))
+    fi
+  done < <(echo "$cover_output" | grep "$file" || true)
+done <<< "$changed_files"
+
+echo ""
+echo "Checked ${checked} functions in ${changed_files_count:=$(echo "$changed_files" | wc -l)} changed files."
+
+if [ "$failed" -gt 0 ]; then
+  echo "ERROR: ${failed} function(s) below ${THRESHOLD}% coverage threshold."
+  exit 1
+fi
+
+echo "SUCCESS: All functions in changed files meet ${THRESHOLD}% coverage threshold."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Display coverage
         run: go tool cover -func=coverage.out
 
+      - name: Delta coverage check
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin main --depth=1
+          bash .github/scripts/delta-coverage.sh coverage.out 95.0 origin/main
+
       - name: Update coverage badge
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Delta coverage check
         if: github.event_name == 'pull_request'
         run: |
-          git fetch origin main --depth=1
+          git fetch origin main --depth=50
           bash .github/scripts/delta-coverage.sh coverage.out 95.0 origin/main
 
       - name: Update coverage badge

--- a/internal/management/management_test.go
+++ b/internal/management/management_test.go
@@ -356,12 +356,17 @@ func TestMetrics_Enabled(t *testing.T) {
 	}
 }
 
-func TestDomainRegistry_PersistNoPersistPath(_ *testing.T) {
+func TestDomainRegistry_PersistNoPersistPath(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("persist with no path panicked: %v", r)
+		}
+	}()
 	cfg := testConfig()
-	r := NewDomainRegistry(cfg, "")
+	reg := NewDomainRegistry(cfg, "")
 	// Add/Remove with no persist path should not panic
-	r.Add("test.example.com")
-	r.Remove("test.example.com")
+	reg.Add("test.example.com")
+	reg.Remove("test.example.com")
 }
 
 func TestDomainRegistry_PersistAtomicWrite(t *testing.T) {

--- a/internal/management/management_test.go
+++ b/internal/management/management_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"ai-anonymizing-proxy/internal/config"
+	"ai-anonymizing-proxy/internal/metrics"
 )
 
 func testConfig() *config.Config {
@@ -299,5 +300,108 @@ func TestRemoveDomain_InvalidDomain(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for invalid domain, got %d", w.Code)
+	}
+}
+
+func TestRemoveDomain_WrongMethod(t *testing.T) {
+	srv, _ := newTestServer("")
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/domains/remove", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET, got %d", w.Code)
+	}
+}
+
+func TestRemoveDomain_EmptyBody(t *testing.T) {
+	srv, _ := newTestServer("")
+	body := `{"domain":""}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/domains/remove", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty domain, got %d", w.Code)
+	}
+}
+
+func TestMetrics_NotEnabled(t *testing.T) {
+	srv, _ := newTestServer("")
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for no metrics, got %d", w.Code)
+	}
+}
+
+func TestMetrics_Enabled(t *testing.T) {
+	cfg := testConfig()
+	reg := NewDomainRegistry(cfg, "")
+	m := &metrics.Metrics{}
+	srv := New(cfg, reg, m)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for metrics, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+}
+
+func TestDomainRegistry_PersistNoPersistPath(_ *testing.T) {
+	cfg := testConfig()
+	r := NewDomainRegistry(cfg, "")
+	// Add/Remove with no persist path should not panic
+	r.Add("test.example.com")
+	r.Remove("test.example.com")
+}
+
+func TestDomainRegistry_PersistAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "domains.json")
+
+	cfg := testConfig()
+	r := NewDomainRegistry(cfg, path)
+
+	// Add and verify file exists
+	r.Add("test.example.com")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("persist file not created: %v", err)
+	}
+
+	// Remove and verify file updated
+	r.Remove("test.example.com")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read persist file: %v", err)
+	}
+	var domains []string
+	if err := json.Unmarshal(data, &domains); err != nil {
+		t.Fatalf("parse persist file: %v", err)
+	}
+	for _, d := range domains {
+		if d == "test.example.com" {
+			t.Error("removed domain should not be in persist file")
+		}
+	}
+}
+
+func TestAuth_MalformedBearerToken(t *testing.T) {
+	srv, _ := newTestServer("secret123")
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/status", nil)
+	req.Header.Set("Authorization", "Basic secret123") // Wrong scheme
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for wrong auth scheme, got %d", w.Code)
 	}
 }

--- a/internal/mitm/mitm_test.go
+++ b/internal/mitm/mitm_test.go
@@ -1,9 +1,12 @@
 package mitm
 
 import (
+	"bufio"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -352,5 +355,265 @@ func TestSingleConnListener_Addr(t *testing.T) {
 	l := &singleConnListener{conn: server}
 	if l.Addr() == nil {
 		t.Error("Addr() should not be nil")
+	}
+}
+
+// --- HandleConn ---
+
+func TestHandleConn_HTTP1(t *testing.T) {
+	certFile, keyFile := tempCA(t)
+	ca, err := LoadCA(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+
+	handlerCalled := make(chan struct{}, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "hello from MITM")
+		handlerCalled <- struct{}{}
+	})
+
+	clientRaw, serverRaw := net.Pipe()
+
+	go HandleConn(serverRaw, "test.example.com", ca, handler)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.cert)
+	tlsClient := tls.Client(clientRaw, &tls.Config{
+		ServerName: "test.example.com",
+		RootCAs:    roots,
+		NextProtos: []string{"http/1.1"},
+	})
+
+	if hsErr := tlsClient.HandshakeContext(t.Context()); hsErr != nil {
+		t.Fatalf("TLS handshake: %v", hsErr)
+	}
+
+	req, _ := http.NewRequestWithContext(t.Context(), "GET", "https://test.example.com/test", nil)
+	if writeErr := req.Write(tlsClient); writeErr != nil {
+		t.Fatalf("write request: %v", writeErr)
+	}
+
+	resp, respErr := http.ReadResponse(bufio.NewReader(tlsClient), req)
+	if respErr != nil {
+		t.Fatalf("ReadResponse: %v", respErr)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	_ = tlsClient.Close()
+
+	select {
+	case <-handlerCalled:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler was not called")
+	}
+}
+
+func TestHandleConn_BadTLSHandshake(t *testing.T) {
+	certFile, keyFile := tempCA(t)
+	ca, err := LoadCA(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create a pipe and close the client side immediately to cause handshake failure
+	clientRaw, serverRaw := net.Pipe()
+	_ = clientRaw.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		HandleConn(serverRaw, "test.example.com", ca, handler)
+	}()
+
+	<-done // HandleConn should return quickly on handshake failure
+}
+
+// --- LoadCA additional edge cases ---
+
+func TestLoadCA_InvalidKeyPEM(t *testing.T) {
+	// Valid cert but garbage key
+	certFile, _ := tempCA(t)
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "bad-key.pem")
+	if err := os.WriteFile(keyFile, []byte("not a pem"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadCA(certFile, keyFile)
+	if err == nil {
+		t.Error("expected error for invalid key PEM")
+	}
+}
+
+func TestLoadCA_InvalidCertDER(t *testing.T) {
+	// PEM wrapper but garbage DER content
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+
+	badCertPEM := "-----BEGIN CERTIFICATE-----\nYmFkZGF0YQ==\n-----END CERTIFICATE-----\n"
+	if err := os.WriteFile(certFile, []byte(badCertPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte(badCertPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadCA(certFile, keyFile)
+	if err == nil {
+		t.Error("expected error for invalid cert DER")
+	}
+}
+
+func TestLoadCA_InvalidKeyDER(t *testing.T) {
+	// Valid cert PEM, but key PEM with bad DER
+	certFile, _ := tempCA(t)
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "key.pem")
+
+	badKeyPEM := "-----BEGIN RSA PRIVATE KEY-----\nYmFkZGF0YQ==\n-----END RSA PRIVATE KEY-----\n"
+	if err := os.WriteFile(keyFile, []byte(badKeyPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadCA(certFile, keyFile)
+	if err == nil {
+		t.Error("expected error for invalid key DER")
+	}
+}
+
+// --- CertFor cache eviction ---
+
+func TestCertFor_CacheEviction(t *testing.T) {
+	certFile, keyFile := tempCA(t)
+	ca, _ := LoadCA(certFile, keyFile)
+
+	// Temporarily shrink the cache to avoid generating 10k certs
+	// Insert entries manually to trigger eviction
+	ca.mu.Lock()
+	for i := 0; i < maxCertCache+1; i++ {
+		ca.cache[fmt.Sprintf("host%d.example.com", i)] = &tls.Certificate{}
+	}
+	ca.mu.Unlock()
+
+	// This CertFor call should trigger cache flush (len > maxCertCache)
+	cert, err := ca.CertFor("trigger-eviction.example.com")
+	if err != nil {
+		t.Fatalf("CertFor: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil cert")
+	}
+
+	ca.mu.RLock()
+	cacheSize := len(ca.cache)
+	ca.mu.RUnlock()
+
+	// After eviction, cache should be small (just the new entry)
+	if cacheSize > 2 {
+		t.Errorf("expected cache ~1 after eviction, got %d", cacheSize)
+	}
+}
+
+// --- GenerateCA error paths ---
+
+func TestHandleConn_H2(t *testing.T) {
+	certFile, keyFile := tempCA(t)
+	ca, err := LoadCA(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+
+	handlerCalled := make(chan struct{}, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "hello h2")
+		handlerCalled <- struct{}{}
+	})
+
+	clientRaw, serverRaw := net.Pipe()
+
+	go HandleConn(serverRaw, "h2test.example.com", ca, handler)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.cert)
+	tlsClient := tls.Client(clientRaw, &tls.Config{
+		ServerName: "h2test.example.com",
+		RootCAs:    roots,
+		NextProtos: []string{"h2"},
+	})
+
+	if hsErr := tlsClient.HandshakeContext(t.Context()); hsErr != nil {
+		t.Fatalf("TLS handshake: %v", hsErr)
+	}
+
+	// Verify we negotiated h2
+	if proto := tlsClient.ConnectionState().NegotiatedProtocol; proto != "h2" {
+		t.Fatalf("expected h2, got %q", proto)
+	}
+
+	_ = tlsClient.Close()
+
+	select {
+	case <-handlerCalled:
+		// OK - handler was called via h2
+	case <-time.After(5 * time.Second):
+		// H2 handler may not have been called before close; that's OK for coverage
+	}
+}
+
+func TestCertFor_ExpiredCert(t *testing.T) {
+	certFile, keyFile := tempCA(t)
+	ca, _ := LoadCA(certFile, keyFile)
+
+	// Generate a cert, then manually expire it
+	host := "expiring.example.com"
+	cert, err := ca.CertFor(host)
+	if err != nil {
+		t.Fatalf("CertFor: %v", err)
+	}
+
+	// Manually set the leaf's NotAfter to be within 1 hour (triggers regeneration)
+	ca.mu.Lock()
+	expired := *cert
+	if expired.Leaf != nil {
+		expiredLeaf := *expired.Leaf
+		expiredLeaf.NotAfter = time.Now().Add(30 * time.Minute) // within 1 hour
+		expired.Leaf = &expiredLeaf
+		ca.cache[host] = &expired
+	}
+	ca.mu.Unlock()
+
+	// This should regenerate the cert
+	cert2, err := ca.CertFor(host)
+	if err != nil {
+		t.Fatalf("CertFor (regenerate): %v", err)
+	}
+	if cert2 == &expired {
+		t.Error("expected new cert after expiry, got same pointer")
+	}
+}
+
+func TestGenerateCA_BadCertPath(t *testing.T) {
+	dir := t.TempDir()
+	err := GenerateCA("/nonexistent/dir/cert.pem", filepath.Join(dir, "key.pem"))
+	if err == nil {
+		t.Error("expected error for bad cert path")
+	}
+}
+
+func TestGenerateCA_BadKeyPath(t *testing.T) {
+	dir := t.TempDir()
+	err := GenerateCA(filepath.Join(dir, "cert.pem"), "/nonexistent/dir/key.pem")
+	if err == nil {
+		t.Error("expected error for bad key path")
 	}
 }

--- a/internal/mitm/mitm_test.go
+++ b/internal/mitm/mitm_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 // tempCA generates a CA into a temp dir and returns (certFile, keyFile).
@@ -532,11 +534,9 @@ func TestHandleConn_H2(t *testing.T) {
 		t.Fatalf("LoadCA: %v", err)
 	}
 
-	handlerCalled := make(chan struct{}, 1)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, "hello h2")
-		handlerCalled <- struct{}{}
 	})
 
 	clientRaw, serverRaw := net.Pipe()
@@ -545,29 +545,42 @@ func TestHandleConn_H2(t *testing.T) {
 
 	roots := x509.NewCertPool()
 	roots.AddCert(ca.cert)
-	tlsClient := tls.Client(clientRaw, &tls.Config{
+	tlsCfg := &tls.Config{
 		ServerName: "h2test.example.com",
 		RootCAs:    roots,
 		NextProtos: []string{"h2"},
-	})
+	}
+	tlsClient := tls.Client(clientRaw, tlsCfg)
 
 	if hsErr := tlsClient.HandshakeContext(t.Context()); hsErr != nil {
 		t.Fatalf("TLS handshake: %v", hsErr)
 	}
 
-	// Verify we negotiated h2
 	if proto := tlsClient.ConnectionState().NegotiatedProtocol; proto != "h2" {
 		t.Fatalf("expected h2, got %q", proto)
 	}
 
-	_ = tlsClient.Close()
-
-	select {
-	case <-handlerCalled:
-		// OK - handler was called via h2
-	case <-time.After(5 * time.Second):
-		// H2 handler may not have been called before close; that's OK for coverage
+	// Make a proper HTTP/2 request using http2.ClientConn
+	h2Transport := &http2.Transport{
+		TLSClientConfig: tlsCfg,
 	}
+	h2Conn, h2Err := h2Transport.NewClientConn(tlsClient)
+	if h2Err != nil {
+		t.Fatalf("h2 client conn: %v", h2Err)
+	}
+
+	req, _ := http.NewRequestWithContext(t.Context(), "GET", "https://h2test.example.com/test", nil)
+	resp, respErr := h2Conn.RoundTrip(req)
+	if respErr != nil {
+		t.Fatalf("h2 RoundTrip: %v", respErr)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	_ = tlsClient.Close()
 }
 
 func TestCertFor_ExpiredCert(t *testing.T) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,15 +1,20 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +22,7 @@ import (
 	"ai-anonymizing-proxy/internal/config"
 	"ai-anonymizing-proxy/internal/management"
 	"ai-anonymizing-proxy/internal/metrics"
+	"ai-anonymizing-proxy/internal/mitm"
 )
 
 // TestIsAuthRequest_PathBypasses verifies that the auth path matching logic
@@ -561,8 +567,12 @@ func TestCopyHeader(t *testing.T) {
 func TestDecompressResponse_Gzip(t *testing.T) {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
-	gw.Write([]byte("hello gzip")) //nolint:errcheck
-	gw.Close()                     //nolint:errcheck
+	if _, err := gw.Write([]byte("hello gzip")); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
 
 	resp := &http.Response{
 		Header: http.Header{},
@@ -584,9 +594,16 @@ func TestDecompressResponse_Gzip(t *testing.T) {
 
 func TestDecompressResponse_Deflate(t *testing.T) {
 	var buf bytes.Buffer
-	fw, _ := flate.NewWriter(&buf, flate.DefaultCompression)
-	fw.Write([]byte("hello deflate")) //nolint:errcheck
-	fw.Close()                        //nolint:errcheck
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	if err != nil {
+		t.Fatalf("flate writer: %v", err)
+	}
+	if _, err := fw.Write([]byte("hello deflate")); err != nil {
+		t.Fatalf("flate write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("flate close: %v", err)
+	}
 
 	resp := &http.Response{
 		Header: http.Header{},
@@ -747,8 +764,12 @@ func TestDeanonymizeResponseBody_GzipEncoded(t *testing.T) {
 
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
-	gw.Write([]byte("compressed body")) //nolint:errcheck
-	gw.Close()                          //nolint:errcheck
+	if _, err := gw.Write([]byte("compressed body")); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
 
 	resp := &http.Response{
 		Header: http.Header{},
@@ -781,7 +802,7 @@ func TestDeanonymizeResponseBody_ReadError(t *testing.T) {
 
 // --- recordMITMMetrics ---
 
-func TestRecordMITMMetrics_NilMetrics(_ *testing.T) {
+func TestRecordMITMMetrics_NilMetrics(t *testing.T) {
 	cfg := &config.Config{
 		OllamaEndpoint: "http://localhost:11434",
 		OllamaModel:    "test",
@@ -789,7 +810,12 @@ func TestRecordMITMMetrics_NilMetrics(_ *testing.T) {
 	domains := management.NewDomainRegistry(cfg, "")
 	srv := New(cfg, domains, nil)
 	defer func() { _ = srv.Close() }()
-	// Should not panic with nil metrics
+	// Verify no panic with nil metrics
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("recordMITMMetrics panicked with nil metrics: %v", r)
+		}
+	}()
 	srv.recordMITMMetrics(false)
 	srv.recordMITMMetrics(true)
 }
@@ -838,7 +864,10 @@ func TestServeHTTP_HTTP_AIAnonymization(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(body) //nolint:errcheck
+		if _, err := w.Write(body); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}))
 	defer backend.Close()
 
@@ -1014,15 +1043,22 @@ func TestAnonymizeRequestBody_ReadError(t *testing.T) {
 func TestForward_WithGzipResponse(t *testing.T) {
 	var gzBuf bytes.Buffer
 	gw := gzip.NewWriter(&gzBuf)
-	gw.Write([]byte(`{"result":"ok"}`)) //nolint:errcheck
-	gw.Close()                          //nolint:errcheck
+	if _, err := gw.Write([]byte(`{"result":"ok"}`)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
 	gzData := gzBuf.Bytes()
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Encoding", "gzip")
 		w.WriteHeader(http.StatusOK)
-		w.Write(gzData) //nolint:errcheck
+		if _, err := w.Write(gzData); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}))
 	defer backend.Close()
 
@@ -1130,7 +1166,10 @@ func TestServeMITMRequest_Integration(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(body) //nolint:errcheck
+		if _, err := w.Write(body); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}))
 	defer backend.Close()
 
@@ -1275,5 +1314,155 @@ func TestForwardMITMRequest_UpstreamError(t *testing.T) {
 
 	if rw.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", rw.Code)
+	}
+}
+
+// --- handleMITMTunnel ---
+
+// hijackResponseWriter wraps an httptest.ResponseRecorder with hijack support
+// using a net.Pipe for the client connection.
+type hijackResponseWriter struct {
+	*httptest.ResponseRecorder
+	clientConn net.Conn
+	serverConn net.Conn
+}
+
+func newHijackResponseWriter() *hijackResponseWriter {
+	client, server := net.Pipe()
+	return &hijackResponseWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		clientConn:       client,
+		serverConn:       server,
+	}
+}
+
+func (h *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReader(h.serverConn), bufio.NewWriter(h.serverConn))
+	return h.serverConn, rw, nil
+}
+
+func TestHandleMITMTunnel(t *testing.T) {
+	// Set up a TLS backend that echoes requests
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(body); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer backend.Close()
+
+	backendHost := strings.TrimPrefix(backend.URL, "https://")
+
+	// Create a proxy server with a real CA
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "ca-cert.pem")
+	keyFile := filepath.Join(dir, "ca-key.pem")
+
+	cfg := &config.Config{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test",
+		AIAPIDomains:   []string{backendHost},
+		AuthDomains:    []string{},
+		AuthPaths:      []string{},
+		CACertFile:     certFile,
+		CAKeyFile:      keyFile,
+		EnabledPacks:   []string{"GLOBAL"},
+	}
+	domains := management.NewDomainRegistry(cfg, "")
+	srv := New(cfg, domains, metrics.New())
+	defer func() { _ = srv.Close() }()
+
+	// Override transport to trust the backend's TLS cert
+	srv.transport = backend.Client().Transport.(*http.Transport) //nolint:errcheck // test setup
+
+	if srv.ca == nil {
+		t.Fatal("expected CA to be loaded")
+	}
+
+	// Create a hijack-capable response writer
+	hw := newHijackResponseWriter()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://"+backendHost, nil)
+	req.Host = backendHost
+	req.RemoteAddr = "127.0.0.1:12345"
+
+	// Run handleMITMTunnel in a goroutine (it will hijack and serve).
+	// The goroutine may outlive the test due to singleConnListener blocking on
+	// second Accept(); this is by design in the production code.
+	go srv.handleMITMTunnel(hw, req, backendHost, backendHost)
+
+	// Act as a TLS client on the hijacked connection.
+	roots := x509.NewCertPool()
+	certPEM, readErr := os.ReadFile(certFile)
+	if readErr != nil {
+		t.Fatalf("read CA cert: %v", readErr)
+	}
+	if !roots.AppendCertsFromPEM(certPEM) {
+		t.Fatal("failed to add CA cert to pool")
+	}
+	tlsClient := tls.Client(hw.clientConn, &tls.Config{
+		ServerName: backendHost,
+		RootCAs:    roots,
+		NextProtos: []string{"http/1.1"},
+	})
+	defer func() { _ = tlsClient.Close() }()
+
+	if hsErr := tlsClient.HandshakeContext(t.Context()); hsErr != nil {
+		t.Fatalf("TLS handshake: %v", hsErr)
+	}
+
+	// Send an HTTP request through the MITM tunnel
+	httpReq, _ := http.NewRequestWithContext(t.Context(), "POST", "https://"+backendHost+"/v1/chat",
+		strings.NewReader(`{"prompt":"test"}`))
+	httpReq.Header.Set("Content-Type", "application/json")
+	if writeErr := httpReq.Write(tlsClient); writeErr != nil {
+		t.Fatalf("write request: %v", writeErr)
+	}
+
+	resp, respErr := http.ReadResponse(bufio.NewReader(tlsClient), httpReq)
+	if respErr != nil {
+		t.Fatalf("ReadResponse: %v", respErr)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 through MITM tunnel, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleMITMTunnel_NoHijacker(t *testing.T) {
+	// When ResponseWriter doesn't support hijacking, should fall through to opaque tunnel
+	srv := newTestProxyServer(t)
+
+	// Manually set up CA so the MITM path is tried
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "ca-cert.pem")
+	keyFile := filepath.Join(dir, "ca-key.pem")
+	if err := mitm.GenerateCA(certFile, keyFile); err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+	ca, err := mitm.LoadCA(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+	srv.ca = ca
+
+	// Use private IP so the opaque tunnel fallback blocks quickly
+	srv.aiDomains.Add("10.0.0.52")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://10.0.0.52:443", nil)
+	req.Host = "10.0.0.52:443"
+	req.RemoteAddr = "127.0.0.1:12345"
+
+	// httptest.NewRecorder does NOT implement http.Hijacker
+	w := httptest.NewRecorder()
+	srv.handleMITMTunnel(w, req, "10.0.0.52:443", "10.0.0.52")
+
+	// Falls through to opaque tunnel which blocks the private IP
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 fallback, got %d", w.Code)
 	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1235,17 +1235,19 @@ func TestHandleTunnel_NonAIDomain(t *testing.T) {
 }
 
 func TestHandleTunnel_AIDomainWithoutCA(t *testing.T) {
+	// CA is nil, so even an AI domain falls through to the opaque tunnel path.
+	// Use a private IP so the tunnel is blocked quickly (no DNS/dial timeout).
 	srv := newTestProxyServer(t)
-	// CA is nil, so even AI domain goes to opaque tunnel
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://api.openai.com:443", nil)
-	req.Host = "api.openai.com:443"
+	srv.aiDomains.Add("10.0.0.52")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://10.0.0.52:443", nil)
+	req.Host = "10.0.0.52:443"
 
 	w := httptest.NewRecorder()
 	srv.handleTunnel(w, req)
 
-	// Should try opaque tunnel (which will fail to dial, returning 502)
-	if w.Code != http.StatusBadGateway {
-		t.Errorf("expected 502, got %d", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"ai-anonymizing-proxy/internal/config"
 	"ai-anonymizing-proxy/internal/management"
@@ -1464,5 +1465,72 @@ func TestHandleMITMTunnel_NoHijacker(t *testing.T) {
 	// Falls through to opaque tunnel which blocks the private IP
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 fallback, got %d", w.Code)
+	}
+}
+
+func TestHandleOpaqueTunnel_HappyPath(t *testing.T) {
+	// Start a local TCP echo server
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	// Create proxy with local dial allowed (bypasses SSRF check at dial time)
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	// Build a hijack-capable ResponseWriter
+	hw := newHijackResponseWriter()
+
+	// Use "localhost:<port>" instead of the raw IP so isPrivateHost (which only
+	// checks literal IPs, not DNS) doesn't block before dialing.
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	host := "localhost:" + port
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodConnect, "http://"+host, nil)
+	req.Host = host
+	req.RemoteAddr = "127.0.0.1:12345"
+
+	go srv.handleOpaqueTunnel(hw, req, host)
+
+	// Send data through the tunnel and verify echo
+	if _, writeErr := hw.clientConn.Write([]byte("ping")); writeErr != nil {
+		t.Fatalf("write to tunnel: %v", writeErr)
+	}
+	buf := make([]byte, 4)
+	if deadlineErr := hw.clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); deadlineErr != nil {
+		t.Fatalf("set deadline: %v", deadlineErr)
+	}
+	n, readErr := hw.clientConn.Read(buf)
+	if readErr != nil {
+		t.Fatalf("read from tunnel: %v", readErr)
+	}
+	if string(buf[:n]) != "ping" {
+		t.Errorf("expected echo 'ping', got %q", buf[:n])
+	}
+	_ = hw.clientConn.Close()
+}
+
+func TestHandleOpaqueTunnel_DialFailure(t *testing.T) {
+	// Use allowLocal so SSRF doesn't block, but point to a port nothing listens on
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodConnect, "http://localhost:1", nil)
+	req.Host = "localhost:1"
+	req.RemoteAddr = "127.0.0.1:12345"
+
+	w := httptest.NewRecorder()
+	srv.handleOpaqueTunnel(w, req, "localhost:1")
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 for dial failure, got %d", w.Code)
 	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2,17 +2,21 @@ package proxy
 
 import (
 	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 
 	"ai-anonymizing-proxy/internal/config"
 	"ai-anonymizing-proxy/internal/management"
+	"ai-anonymizing-proxy/internal/metrics"
 )
 
 // TestIsAuthRequest_PathBypasses verifies that the auth path matching logic
@@ -410,5 +414,864 @@ func TestProcessMITMRequestBody_SuccessfulAnonymization(t *testing.T) {
 	// Clean up the session
 	if sessionID != "" {
 		srv.anon.DeleteSession(sessionID)
+	}
+}
+
+// --- helpers for new tests ---
+
+func newTestProxyServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test",
+		AIAPIDomains:   []string{"api.openai.com"},
+		AuthDomains:    []string{"auth.example.com"},
+		AuthPaths:      []string{"/oauth"},
+		EnabledPacks:   []string{"GLOBAL"},
+	}
+	domains := management.NewDomainRegistry(cfg, "")
+	srv := New(cfg, domains, metrics.New())
+	t.Cleanup(func() { _ = srv.Close() })
+	return srv
+}
+
+// newTestProxyServerAllowLocal creates a proxy that allows connections to
+// localhost (overriding SSRF protection) so httptest backends are reachable.
+func newTestProxyServerAllowLocal(t *testing.T, aiDomains, authDomains []string) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test",
+		AIAPIDomains:   aiDomains,
+		AuthDomains:    authDomains,
+		AuthPaths:      []string{"/oauth"},
+		EnabledPacks:   []string{"GLOBAL"},
+	}
+	domains := management.NewDomainRegistry(cfg, "")
+	srv := New(cfg, domains, metrics.New())
+	// Override dialContext to allow local connections (bypass SSRF for tests)
+	dialer := &net.Dialer{Timeout: 5e9}
+	srv.dialContext = dialer.DialContext
+	srv.transport.DialContext = dialer.DialContext
+	t.Cleanup(func() { _ = srv.Close() })
+	return srv
+}
+
+// backendHostPort returns the "localhost:<port>" form of an httptest server URL.
+// Using "localhost" instead of the raw IP avoids isPrivateHost literal IP checks.
+func backendHostPort(t *testing.T, serverURL, scheme string) string {
+	t.Helper()
+	raw := strings.TrimPrefix(serverURL, scheme+"://")
+	_, port, err := net.SplitHostPort(raw)
+	if err != nil {
+		t.Fatalf("bad server URL %q: %v", serverURL, err)
+	}
+	return "localhost:" + port
+}
+
+// --- hashRemoteAddr ---
+
+func TestHashRemoteAddr(t *testing.T) {
+	h := hashRemoteAddr("127.0.0.1:12345")
+	if len(h) != 8 {
+		t.Errorf("expected 8-char hash, got %d chars: %q", len(h), h)
+	}
+	// Deterministic
+	if h2 := hashRemoteAddr("127.0.0.1:12345"); h != h2 {
+		t.Errorf("expected deterministic hash, got %q then %q", h, h2)
+	}
+	// Different input, different hash
+	if h3 := hashRemoteAddr("192.168.1.1:80"); h == h3 {
+		t.Error("different addresses should produce different hashes")
+	}
+}
+
+// --- toSet ---
+
+func TestToSet(t *testing.T) {
+	s := toSet([]string{"a", "b", "c"})
+	if len(s) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(s))
+	}
+	for _, k := range []string{"a", "b", "c"} {
+		if !s[k] {
+			t.Errorf("expected %q in set", k)
+		}
+	}
+	if s["d"] {
+		t.Error("unexpected key in set")
+	}
+	// Empty input
+	s2 := toSet(nil)
+	if len(s2) != 0 {
+		t.Errorf("expected empty set, got %d", len(s2))
+	}
+}
+
+// --- removeHopByHop ---
+
+func TestRemoveHopByHop(t *testing.T) {
+	h := http.Header{}
+	h.Set("Connection", "keep-alive")
+	h.Set("Keep-Alive", "timeout=5")
+	h.Set("Proxy-Authorization", "Basic abc")
+	h.Set("Content-Type", "application/json")
+	h.Set("X-Custom", "value")
+
+	removeHopByHop(h)
+
+	if h.Get("Connection") != "" {
+		t.Error("Connection header should be removed")
+	}
+	if h.Get("Keep-Alive") != "" {
+		t.Error("Keep-Alive header should be removed")
+	}
+	if h.Get("Proxy-Authorization") != "" {
+		t.Error("Proxy-Authorization header should be removed")
+	}
+	if h.Get("Content-Type") != "application/json" {
+		t.Error("Content-Type should be preserved")
+	}
+	if h.Get("X-Custom") != "value" {
+		t.Error("X-Custom should be preserved")
+	}
+}
+
+// --- copyHeader ---
+
+func TestCopyHeader(t *testing.T) {
+	src := http.Header{}
+	src.Set("Content-Type", "text/plain")
+	src.Add("X-Multi", "a")
+	src.Add("X-Multi", "b")
+
+	dst := http.Header{}
+	copyHeader(dst, src)
+
+	if dst.Get("Content-Type") != "text/plain" {
+		t.Errorf("Content-Type not copied: %q", dst.Get("Content-Type"))
+	}
+	if vals := dst.Values("X-Multi"); len(vals) != 2 {
+		t.Errorf("expected 2 X-Multi values, got %d", len(vals))
+	}
+}
+
+// --- decompressResponse ---
+
+func TestDecompressResponse_Gzip(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte("hello gzip")) //nolint:errcheck
+	gw.Close()                     //nolint:errcheck
+
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(&buf),
+	}
+	resp.Header.Set("Content-Encoding", "gzip")
+
+	if err := decompressResponse(resp); err != nil {
+		t.Fatalf("decompressResponse gzip: %v", err)
+	}
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Error("Content-Encoding should be removed after decompression")
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello gzip" {
+		t.Errorf("expected 'hello gzip', got %q", string(body))
+	}
+}
+
+func TestDecompressResponse_Deflate(t *testing.T) {
+	var buf bytes.Buffer
+	fw, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+	fw.Write([]byte("hello deflate")) //nolint:errcheck
+	fw.Close()                        //nolint:errcheck
+
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(&buf),
+	}
+	resp.Header.Set("Content-Encoding", "deflate")
+
+	if err := decompressResponse(resp); err != nil {
+		t.Fatalf("decompressResponse deflate: %v", err)
+	}
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Error("Content-Encoding should be removed after decompression")
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello deflate" {
+		t.Errorf("expected 'hello deflate', got %q", string(body))
+	}
+}
+
+func TestDecompressResponse_Identity(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("plain")),
+	}
+	resp.Header.Set("Content-Encoding", "identity")
+
+	if err := decompressResponse(resp); err != nil {
+		t.Fatalf("decompressResponse identity: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "plain" {
+		t.Errorf("expected 'plain', got %q", string(body))
+	}
+}
+
+func TestDecompressResponse_Empty(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("plain")),
+	}
+	if err := decompressResponse(resp); err != nil {
+		t.Fatalf("decompressResponse empty: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "plain" {
+		t.Errorf("expected 'plain', got %q", string(body))
+	}
+}
+
+func TestDecompressResponse_Unsupported(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("data")),
+	}
+	resp.Header.Set("Content-Encoding", "br")
+	// Should not error, just log and leave body unchanged
+	if err := decompressResponse(resp); err != nil {
+		t.Fatalf("decompressResponse unsupported: %v", err)
+	}
+}
+
+func TestDecompressResponse_InvalidGzip(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("not gzip data")),
+	}
+	resp.Header.Set("Content-Encoding", "gzip")
+	err := decompressResponse(resp)
+	if err == nil {
+		t.Error("expected error for invalid gzip data")
+	}
+}
+
+// --- isStreamingResponse ---
+
+func TestIsStreamingResponse(t *testing.T) {
+	tests := []struct {
+		contentType string
+		want        bool
+	}{
+		{"text/event-stream", true},
+		{"text/event-stream; charset=utf-8", true},
+		{"application/json", false},
+		{"text/plain", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Content-Type", tt.contentType)
+		if got := isStreamingResponse(resp); got != tt.want {
+			t.Errorf("isStreamingResponse(%q) = %v, want %v", tt.contentType, got, tt.want)
+		}
+	}
+}
+
+// --- ReverseProxy ---
+
+func TestReverseProxy(t *testing.T) {
+	srv := newTestProxyServer(t)
+	rp := srv.ReverseProxy()
+	if rp == nil {
+		t.Fatal("ReverseProxy() returned nil")
+	}
+}
+
+// --- deanonymizeResponseBody ---
+
+func TestDeanonymizeResponseBody_NoSessionID(t *testing.T) {
+	srv := newTestProxyServer(t)
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("body")),
+	}
+	// Should not panic or modify when sessionID is empty
+	srv.deanonymizeResponseBody(resp, "")
+}
+
+func TestDeanonymizeResponseBody_NilResp(t *testing.T) {
+	srv := newTestProxyServer(t)
+	// Should not panic
+	srv.deanonymizeResponseBody(nil, "session123")
+}
+
+func TestDeanonymizeResponseBody_NonStreaming(t *testing.T) {
+	srv := newTestProxyServer(t)
+	resp := &http.Response{
+		Header:        http.Header{},
+		Body:          io.NopCloser(strings.NewReader("hello world")),
+		ContentLength: 11,
+	}
+	resp.Header.Set("Content-Type", "application/json")
+
+	srv.deanonymizeResponseBody(resp, "test-session")
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello world" {
+		t.Errorf("expected 'hello world', got %q", string(body))
+	}
+}
+
+func TestDeanonymizeResponseBody_Streaming(t *testing.T) {
+	srv := newTestProxyServer(t)
+	resp := &http.Response{
+		Header:        http.Header{},
+		Body:          io.NopCloser(strings.NewReader("data: hello\n\n")),
+		ContentLength: -1,
+	}
+	resp.Header.Set("Content-Type", "text/event-stream")
+
+	srv.deanonymizeResponseBody(resp, "test-session")
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "hello") {
+		t.Errorf("expected body to contain 'hello', got %q", string(body))
+	}
+}
+
+func TestDeanonymizeResponseBody_GzipEncoded(t *testing.T) {
+	srv := newTestProxyServer(t)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte("compressed body")) //nolint:errcheck
+	gw.Close()                          //nolint:errcheck
+
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(&buf),
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set("Content-Encoding", "gzip")
+
+	srv.deanonymizeResponseBody(resp, "test-session")
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "compressed body" {
+		t.Errorf("expected 'compressed body', got %q", string(body))
+	}
+}
+
+func TestDeanonymizeResponseBody_ReadError(t *testing.T) {
+	srv := newTestProxyServer(t)
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   errorReader{},
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	// Should not panic; body should be replaced with empty
+	srv.deanonymizeResponseBody(resp, "test-session")
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) != 0 {
+		t.Errorf("expected empty body on read error, got %q", string(body))
+	}
+}
+
+// --- recordMITMMetrics ---
+
+func TestRecordMITMMetrics_NilMetrics(_ *testing.T) {
+	cfg := &config.Config{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test",
+	}
+	domains := management.NewDomainRegistry(cfg, "")
+	srv := New(cfg, domains, nil)
+	defer func() { _ = srv.Close() }()
+	// Should not panic with nil metrics
+	srv.recordMITMMetrics(false)
+	srv.recordMITMMetrics(true)
+}
+
+func TestRecordMITMMetrics_WithMetrics(t *testing.T) {
+	srv := newTestProxyServer(t)
+	srv.recordMITMMetrics(false) // anonymized
+	srv.recordMITMMetrics(true)  // auth
+
+	snap := srv.m.Snapshot()
+	if snap.Requests.Total != 2 {
+		t.Errorf("expected 2 total requests, got %d", snap.Requests.Total)
+	}
+}
+
+// --- ServeHTTP dispatching ---
+
+func TestServeHTTP_HTTP_Passthrough(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "backend response")
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://"+host+"/test", nil)
+	req.Host = host
+	req.URL.Host = host
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "backend response") {
+		t.Errorf("expected 'backend response', got %q", w.Body.String())
+	}
+}
+
+func TestServeHTTP_HTTP_AIAnonymization(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body) //nolint:errcheck
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	srv := newTestProxyServerAllowLocal(t, []string{host}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://"+host+"/v1/chat",
+		strings.NewReader(`{"message":"hello"}`))
+	req.Host = host
+	req.URL.Host = host
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestServeHTTP_HTTP_AuthPassthrough(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "auth OK")
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	srv := newTestProxyServerAllowLocal(t, []string{host}, []string{host})
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://"+host+"/oauth/callback", nil)
+	req.Host = host
+	req.URL.Host = host
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandleHTTP_PrivateHostBlocked(t *testing.T) {
+	srv := newTestProxyServer(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.52:8080/test", nil)
+	req.Host = "10.0.0.52:8080"
+	req.URL.Host = "10.0.0.52:8080"
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for private host, got %d", w.Code)
+	}
+}
+
+func TestHandleHTTP_UpstreamError(t *testing.T) {
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	// Point to a non-existent backend
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://localhost:1/nonexistent", nil)
+	req.Host = "localhost:1"
+	req.URL.Host = "localhost:1"
+
+	w := httptest.NewRecorder()
+	srv.handleHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestHandleHTTP_EmptyBody_AIRequest(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	srv := newTestProxyServerAllowLocal(t, []string{host}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://"+host+"/v1/models", nil)
+	req.Host = host
+	req.URL.Host = host
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// --- handleTunnel / CONNECT ---
+
+func TestServeHTTP_CONNECT_PrivateHost(t *testing.T) {
+	srv := newTestProxyServer(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://10.0.0.52:443", nil)
+	req.Host = "10.0.0.52:443"
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	// handleOpaqueTunnel should block private addresses
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for CONNECT to private host, got %d", w.Code)
+	}
+}
+
+// --- anonymizeRequestBody ---
+
+func TestAnonymizeRequestBody_NilBody(t *testing.T) {
+	srv := newTestProxyServer(t)
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://example.com", nil)
+	sessionID, err := srv.anonymizeRequestBody(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionID != "" {
+		t.Errorf("expected empty sessionID for nil body, got %q", sessionID)
+	}
+}
+
+func TestAnonymizeRequestBody_ZeroContentLength(t *testing.T) {
+	srv := newTestProxyServer(t)
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://example.com",
+		strings.NewReader(""))
+	req.ContentLength = 0
+	sessionID, err := srv.anonymizeRequestBody(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionID != "" {
+		t.Errorf("expected empty sessionID for zero content length, got %q", sessionID)
+	}
+}
+
+func TestAnonymizeRequestBody_ValidBody(t *testing.T) {
+	srv := newTestProxyServer(t)
+	body := `{"prompt":"test message"}`
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://example.com",
+		strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	sessionID, err := srv.anonymizeRequestBody(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionID == "" {
+		t.Error("expected non-empty sessionID")
+	}
+	// Verify body was replaced
+	newBody, _ := io.ReadAll(req.Body)
+	if len(newBody) == 0 {
+		t.Error("expected non-empty body after anonymization")
+	}
+	srv.anon.DeleteSession(sessionID)
+}
+
+func TestAnonymizeRequestBody_ReadError(t *testing.T) {
+	srv := newTestProxyServer(t)
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://example.com", errorReader{})
+	req.ContentLength = 100
+	_, err := srv.anonymizeRequestBody(req)
+	if err == nil {
+		t.Error("expected error for read error")
+	}
+}
+
+// --- forward with response decompression ---
+
+func TestForward_WithGzipResponse(t *testing.T) {
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	gw.Write([]byte(`{"result":"ok"}`)) //nolint:errcheck
+	gw.Close()                          //nolint:errcheck
+	gzData := gzBuf.Bytes()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		w.Write(gzData) //nolint:errcheck
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	srv := newTestProxyServerAllowLocal(t, []string{host}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://"+host+"/v1/chat",
+		strings.NewReader(`{"message":"hello"}`))
+	req.Host = host
+	req.URL.Host = host
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(`{"message":"hello"}`))
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// --- New with CA files ---
+
+func TestNew_WithInvalidCAFiles(t *testing.T) {
+	cfg := &config.Config{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test",
+		CACertFile:     "/nonexistent/cert.pem",
+		CAKeyFile:      "/nonexistent/key.pem",
+		EnabledPacks:   []string{"GLOBAL"},
+	}
+	domains := management.NewDomainRegistry(cfg, "")
+	srv := New(cfg, domains, nil)
+	defer func() { _ = srv.Close() }()
+	if srv.ca != nil {
+		t.Error("expected nil CA with nonexistent cert files")
+	}
+}
+
+// --- Close ---
+
+func TestServer_Close(t *testing.T) {
+	srv := newTestProxyServer(t)
+	if err := srv.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+// --- ssrfSafeDialContext edge cases ---
+
+func TestSsrfSafeDialContext_NoPort(t *testing.T) {
+	dialer := &net.Dialer{Timeout: 1}
+	dialFn := ssrfSafeDialContext(dialer)
+	// Address without port — falls back to plain DialContext
+	_, err := dialFn(t.Context(), "tcp", "invalid-no-port")
+	if err == nil {
+		t.Error("expected error for address without port")
+	}
+}
+
+// --- handleHTTP with host from URL ---
+
+func TestHandleHTTP_HostFromURL(t *testing.T) {
+	// When req.Host is empty, handleHTTP should fall back to URL.Host for domain matching.
+	// We can't test a real round-trip to localhost (SSRF), but we can verify the code path
+	// by using a private host that should be blocked — the key is it takes the URL.Host path.
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.52:8080/test", nil)
+	req.Host = "" // empty host, should fall back to URL.Host
+	req.URL.Host = "10.0.0.52:8080"
+
+	w := httptest.NewRecorder()
+	srv.handleHTTP(w, req)
+
+	// Private host gets blocked — but it exercises the host-from-URL code path
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for private host via URL, got %d", w.Code)
+	}
+}
+
+// --- forward sets scheme ---
+
+func TestForward_SetsScheme(t *testing.T) {
+	// When URL.Scheme is empty, forward() should default to "http"
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.52:8080/test", nil)
+	req.URL.Scheme = ""
+	req.URL.Host = "10.0.0.52:8080"
+
+	w := httptest.NewRecorder()
+	srv.forward(w, req, "")
+
+	// Private host gets blocked, but the code path that sets scheme is exercised
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for private host, got %d", w.Code)
+	}
+}
+
+// --- serveMITMRequest (integration) ---
+
+func TestServeMITMRequest_Integration(t *testing.T) {
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body) //nolint:errcheck
+	}))
+	defer backend.Close()
+
+	backendHost := strings.TrimPrefix(backend.URL, "https://")
+	srv := newTestProxyServerAllowLocal(t, []string{backendHost}, nil)
+	srv.transport, _ = backend.Client().Transport.(*http.Transport)
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST", backend.URL+"/v1/chat",
+		strings.NewReader(`{"prompt":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(`{"prompt":"test"}`))
+
+	rw := httptest.NewRecorder()
+	ctx := mitmContext{host: backendHost, domain: backendHost, remoteHash: "test"}
+
+	srv.serveMITMRequest(rw, req, ctx)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rw.Code, rw.Body.String())
+	}
+}
+
+func TestServeMITMRequest_AuthPassthrough(t *testing.T) {
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "auth pass")
+	}))
+	defer backend.Close()
+
+	backendHost := strings.TrimPrefix(backend.URL, "https://")
+	srv := newTestProxyServerAllowLocal(t, []string{backendHost}, []string{backendHost})
+	srv.transport, _ = backend.Client().Transport.(*http.Transport)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", backend.URL+"/anything", nil)
+	rw := httptest.NewRecorder()
+	ctx := mitmContext{host: backendHost, domain: backendHost, remoteHash: "test"}
+
+	srv.serveMITMRequest(rw, req, ctx)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rw.Code)
+	}
+}
+
+// --- handleHTTP metrics and logging branches ---
+
+func TestHandleHTTP_PassthroughMetrics(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	// Non-AI, non-auth domain: exercises the passthrough metrics path
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://"+host+"/test", nil)
+	req.Host = host
+	req.URL.Host = host
+
+	w := httptest.NewRecorder()
+	srv.handleHTTP(w, req)
+
+	snap := srv.m.Snapshot()
+	if snap.Requests.Passthrough == 0 {
+		t.Error("expected passthrough counter to be incremented")
+	}
+}
+
+func TestHandleHTTP_AIAnonymizationError(t *testing.T) {
+	host := "example.com:80"
+	srv := newTestProxyServerAllowLocal(t, []string{"example.com"}, nil)
+
+	// AI request with body that causes read error
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://"+host+"/v1/chat", errorReader{})
+	req.Host = host
+	req.URL.Host = host
+	req.ContentLength = 100
+
+	w := httptest.NewRecorder()
+	srv.handleHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d", w.Code)
+	}
+}
+
+// --- handleTunnel dispatch ---
+
+func TestHandleTunnel_NonAIDomain(t *testing.T) {
+	srv := newTestProxyServer(t)
+	// CONNECT to private IP — goes through handleOpaqueTunnel path
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://10.0.0.52:443", nil)
+	req.Host = "10.0.0.52:443"
+
+	w := httptest.NewRecorder()
+	srv.handleTunnel(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestHandleTunnel_AIDomainWithoutCA(t *testing.T) {
+	srv := newTestProxyServer(t)
+	// CA is nil, so even AI domain goes to opaque tunnel
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "http://api.openai.com:443", nil)
+	req.Host = "api.openai.com:443"
+
+	w := httptest.NewRecorder()
+	srv.handleTunnel(w, req)
+
+	// Should try opaque tunnel (which will fail to dial, returning 502)
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+// --- ssrfSafeDialContext additional coverage ---
+
+func TestSsrfSafeDialContext_ResolvesToPrivate(t *testing.T) {
+	dialer := &net.Dialer{Timeout: 1e9}
+	dialFn := ssrfSafeDialContext(dialer)
+
+	// localhost resolves to 127.0.0.1 or ::1, both private
+	_, err := dialFn(t.Context(), "tcp", "localhost:80")
+	if err == nil {
+		t.Fatal("expected error dialing localhost")
+	}
+}
+
+func TestForwardMITMRequest_UpstreamError(t *testing.T) {
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "https://localhost:1/fail", nil)
+	req.RequestURI = ""
+	rw := httptest.NewRecorder()
+
+	srv.forwardMITMRequest(rw, req, "")
+
+	if rw.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", rw.Code)
 	}
 }


### PR DESCRIPTION
## Summary
This PR significantly expands test coverage for the proxy and MITM packages by adding 100+ new test cases covering request/response handling, compression, anonymization, SSRF protection, and edge cases. It also introduces a delta coverage check script to enforce coverage thresholds on changed code.

## Key Changes

### Test Coverage Additions

**Proxy Package (`internal/proxy/proxy_test.go`)**
- Added helper functions for test setup (`newTestProxyServer`, `newTestProxyServerAllowLocal`, `backendHostPort`)
- Utility function tests: `hashRemoteAddr`, `toSet`, `removeHopByHop`, `copyHeader`
- Response decompression tests: gzip, deflate, identity, empty, unsupported, and invalid data handling
- Streaming response detection tests
- Response body deanonymization tests covering non-streaming, streaming, gzip-encoded, and error cases
- MITM metrics recording tests
- HTTP request handling tests: passthrough, AI anonymization, auth passthrough, private host blocking, upstream errors
- CONNECT tunnel tests: private host blocking, missing CA handling
- Request anonymization tests: nil body, zero content length, valid body, read errors
- Forward request tests with gzip response handling
- CA file loading tests with invalid paths
- SSRF protection edge cases: no port, localhost resolution
- Integration tests for MITM request serving with both anonymization and auth passthrough

**MITM Package (`internal/mitm/mitm_test.go`)**
- HTTP/1.1 connection handling test with TLS handshake
- Bad TLS handshake error handling
- CA loading edge cases: invalid key PEM, invalid cert DER, invalid key DER
- Certificate cache eviction test
- HTTP/2 protocol negotiation test
- Expired certificate regeneration test
- CA generation error paths: bad cert and key file paths

**Management Package (`internal/management/management_test.go`)**
- Domain removal with wrong HTTP method
- Domain removal with empty body validation
- Metrics endpoint availability tests (disabled and enabled states)
- Domain registry persistence tests: no persist path, atomic writes
- Authentication tests: malformed bearer token handling

### CI/CD Improvements
- Added `delta-coverage.sh` script to enforce coverage thresholds on changed code in pull requests
- Integrated delta coverage check into GitHub Actions CI workflow
- Script validates that all functions in modified files meet the specified coverage threshold (default 95%)

## Implementation Details

- Test helpers use `httptest` servers to simulate real HTTP backends while bypassing SSRF protections for testing
- Compression tests verify both successful decompression and error handling for gzip/deflate formats
- MITM tests use `net.Pipe()` for in-process TLS connection testing without external network calls
- Delta coverage script uses `go tool cover` output parsing and `git diff` to identify changed files and validate coverage
- All new tests follow existing patterns and include proper cleanup with `t.Cleanup()`

https://claude.ai/code/session_0139or3GJtSP937fLz42zeKU