### PR TITLE
feat(mitm): make import-ca-windows actually install the CA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,9 @@ import-ca-linux:
 	sudo update-ca-certificates
 	@echo "CA trusted on Linux."
 
-# Import CA into Windows trust store (run from elevated prompt)
+# Import CA into Windows trust store (requires elevated PowerShell)
 import-ca-windows:
-	@echo "Run from an elevated Command Prompt:"
-	@echo "  certutil -addstore -f \"ROOT\" $(CA_CERT)"
+	powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/import-ca.ps1 -CaPath "$(CA_CERT)"
 
 # Quick smoke test against a running proxy
 smoke:

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ import-ca-linux:
 
 # Import CA into Windows trust store (requires elevated PowerShell)
 import-ca-windows:
+	@test -n "$(CA_CERT)" || { echo "Error: CA_CERT is not set. Run 'make generate-ca' first or set CA_CERT=path/to/ca.pem."; exit 1; }
 	powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/import-ca.ps1 -CaPath "$(CA_CERT)"
 
 # Quick smoke test against a running proxy

--- a/scripts/import-ca.ps1
+++ b/scripts/import-ca.ps1
@@ -4,7 +4,11 @@
 .DESCRIPTION
     Adds the specified CA certificate to Cert:\LocalMachine\Root so that
     TLS connections through the MITM proxy are trusted system-wide.
-    Must be run from an elevated (Administrator) PowerShell prompt.
+    Requires Administrator privileges. Typically invoked via
+    `make import-ca-windows` from an elevated shell, but can also be run
+    directly in an elevated PowerShell session.
+    Accepts PEM or DER encoded certificates. PEM files are automatically
+    converted to DER before import.
 .PARAMETER CaPath
     Path to the CA certificate file (PEM or DER).
 #>
@@ -18,8 +22,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# Resolve to absolute path and verify the file exists
-$resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($CaPath)
+# Convert to absolute path (resolves relative to process CWD, not PS provider location)
+$resolvedPath = [System.IO.Path]::GetFullPath($CaPath)
 if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
     Write-Error "CA certificate not found: $resolvedPath"
     exit 1
@@ -33,5 +37,44 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
     exit 1
 }
 
-Import-Certificate -FilePath $resolvedPath -CertStoreLocation 'Cert:\LocalMachine\Root' | Out-Null
-Write-Output "CA trusted on Windows."
+# Read the certificate file — convert PEM to DER if needed
+$rawContent = [System.IO.File]::ReadAllText($resolvedPath)
+if ($rawContent -match '-----BEGIN CERTIFICATE-----') {
+    $base64 = $rawContent -replace '-----BEGIN CERTIFICATE-----' -replace '-----END CERTIFICATE-----' -replace '\s'
+    $derBytes = [Convert]::FromBase64String($base64)
+    $tempDer = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'ai-proxy-ca.cer')
+    [System.IO.File]::WriteAllBytes($tempDer, $derBytes)
+    $importPath = $tempDer
+} else {
+    $importPath = $resolvedPath
+    $tempDer = $null
+}
+
+try {
+    # Idempotency check — skip if already trusted
+    $incoming = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($importPath)
+    $existing = Get-ChildItem 'Cert:\LocalMachine\Root' | Where-Object {
+        $_.Thumbprint -eq $incoming.Thumbprint
+    }
+    if ($existing) {
+        Write-Output "CA already trusted on Windows (thumbprint: $($existing.Thumbprint))."
+        exit 0
+    }
+
+    # Import and verify
+    $cert = Import-Certificate -FilePath $importPath -CertStoreLocation 'Cert:\LocalMachine\Root'
+    if (-not $cert) {
+        Write-Error "Import-Certificate completed but returned no certificate object."
+        exit 1
+    }
+    $installed = Get-ChildItem 'Cert:\LocalMachine\Root' | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+    if (-not $installed) {
+        Write-Error "Certificate not found in store after import — Group Policy or security software may have blocked it."
+        exit 1
+    }
+    Write-Output "CA trusted on Windows (thumbprint: $($cert.Thumbprint))."
+} finally {
+    if ($tempDer -and (Test-Path -LiteralPath $tempDer)) {
+        Remove-Item -LiteralPath $tempDer -Force
+    }
+}

--- a/scripts/import-ca.ps1
+++ b/scripts/import-ca.ps1
@@ -38,11 +38,18 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administra
 }
 
 # Read the certificate file — convert PEM to DER if needed
-$rawContent = [System.IO.File]::ReadAllText($resolvedPath)
+$rawContent = [System.IO.File]::ReadAllText($resolvedPath).TrimStart([char]0xFEFF)
 if ($rawContent -match '-----BEGIN CERTIFICATE-----') {
+    if (($rawContent | Select-String -Pattern '-----BEGIN CERTIFICATE-----' -AllMatches).Matches.Count -gt 1) {
+        Write-Error "PEM file contains multiple certificates. Provide a single CA certificate."
+        exit 1
+    }
     $base64 = $rawContent -replace '-----BEGIN CERTIFICATE-----' -replace '-----END CERTIFICATE-----' -replace '\s'
     $derBytes = [Convert]::FromBase64String($base64)
-    $tempDer = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), 'ai-proxy-ca.cer')
+    $tempDer = [System.IO.Path]::Combine(
+        [System.IO.Path]::GetTempPath(),
+        "ai-proxy-ca-$PID.cer"
+    )
     [System.IO.File]::WriteAllBytes($tempDer, $derBytes)
     $importPath = $tempDer
 } else {
@@ -73,6 +80,9 @@ try {
         exit 1
     }
     Write-Output "CA trusted on Windows (thumbprint: $($cert.Thumbprint))."
+} catch {
+    Write-Error "Failed to import CA certificate: $_"
+    exit 1
 } finally {
     if ($tempDer -and (Test-Path -LiteralPath $tempDer)) {
         Remove-Item -LiteralPath $tempDer -Force

--- a/scripts/import-ca.ps1
+++ b/scripts/import-ca.ps1
@@ -1,0 +1,37 @@
+﻿<#
+.SYNOPSIS
+    Import the AI Proxy CA certificate into the Windows trust store.
+.DESCRIPTION
+    Adds the specified CA certificate to Cert:\LocalMachine\Root so that
+    TLS connections through the MITM proxy are trusted system-wide.
+    Must be run from an elevated (Administrator) PowerShell prompt.
+.PARAMETER CaPath
+    Path to the CA certificate file (PEM or DER).
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CaPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Resolve to absolute path and verify the file exists
+$resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($CaPath)
+if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
+    Write-Error "CA certificate not found: $resolvedPath"
+    exit 1
+}
+
+# Elevation check — fail cleanly rather than self-elevating
+$identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]$identity
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "This target must be run from an elevated PowerShell prompt (Run as Administrator)."
+    exit 1
+}
+
+Import-Certificate -FilePath $resolvedPath -CertStoreLocation 'Cert:\LocalMachine\Root' | Out-Null
+Write-Output "CA trusted on Windows."


### PR DESCRIPTION
Closes the parity gap with `import-ca-macos` / `import-ca-linux`, which perform real installs. Before this change, `import-ca-windows` only echoed instructions.

## Changes

- New `scripts/import-ca.ps1` — PowerShell installer using `Import-Certificate` into `Cert:\LocalMachine\Root`. Requires an elevated shell (matches the `sudo` requirement of the Unix targets). Fails cleanly with a clear message if not elevated.
- `Makefile`: `import-ca-windows` now invokes the script instead of printing instructions.

## Scope

System-wide install only, matching the Unix targets. Per-user variants across all three OSes can be added uniformly in a follow-up if wanted.

## Elevation design

Script does not self-elevate — it checks and fails loudly if not admin. Self-elevation via `Start-Process -Verb RunAs` was considered and rejected because it detaches from the parent process, causing `make` to report success even when the user cancels the UAC prompt.

## Testing

- Makefile recipe expansion verified via `make -n import-ca-windows`
- PS AST parse via `[System.Management.Automation.Language.Parser]::ParseFile` — passed
- `Invoke-ScriptAnalyzer -EnableExit` — passed (baseline for the new script)
- `make lint` — passed (0 issues)
- **Not executed on a live Windows host.** Manual verification on Windows required before merge.

## Follow-up

A docs PR referencing `make import-ca-windows` alongside the macOS/Linux targets in `docs/tls-mitm.md` is queued as the next branch.