### PR TITLE
fix(deps): bump go directive to 1.26.2 to clear stdlib vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ai-anonymizing-proxy
 
-go 1.26.1
+go 1.26.2
 
 require (
 	go.etcd.io/bbolt v1.4.3


### PR DESCRIPTION
## Summary

`govulncheck ./...` failed on `main` (exit code 3) with four stdlib
advisories reached through the MITM / proxy / streaming code paths.
All four are fixed in `go1.26.2`. This PR bumps the `go` directive in
`go.mod` from `1.26.1` to `1.26.2` — the smallest change that clears
every reported advisory. No third-party module bumps were needed.

Security Scan is a required CI job, so this also unblocks #89.

## Advisories cleared

All were reported against the go1.26.1 stdlib and are fixed in
go1.26.2:

- **GO-2026-4947** — `crypto/x509`: Unexpected work during chain building.
  Reached via `mitm.HandleConn` → `tls.Conn.HandshakeContext` → `x509.Certificate.Verify`.
- **GO-2026-4946** — `crypto/x509`: Inefficient policy validation. Same call chain.
- **GO-2026-4870** — `crypto/tls`: Unauthenticated TLS 1.3 KeyUpdate record can cause
  persistent connection retention and DoS. Reached via `mitm.HandleConn`,
  `anonymizer.readLoop`, and `proxy.Server.forward`.
- **GO-2026-4866** — `crypto/x509`: Case-sensitive `excludedSubtrees` name
  constraints cause Auth Bypass. Reached via the `HandshakeContext` call chain.

## Verification

Local results with the bumped toolchain (`go1.26.2`):

- `govulncheck ./...` — exit 0, `No vulnerabilities found.` (was exit 3 with 4 findings)
- `go build ./...` — pass
- `go test -race -count=1 ./...` — pass across all packages
- `make lint` (`golangci-lint run ./...`) — `0 issues.`

## Test plan

- [x] Reproduced the failure on `main` with govulncheck (4 findings, exit 3)
- [x] Confirmed all 4 advisories list `go1.26.2` as the minimum fixed version
- [x] `govulncheck ./...` exits 0 after the bump
- [x] `go build ./...` passes
- [x] `go test -race -count=1 ./...` passes
- [x] `make lint` passes
- [ ] CI Security Scan goes green on this PR

Closes #90
