### PR TITLE
feat: user-scope CA trust + install on macOS, Linux, Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,15 @@ import-ca-windows:
 
 # --- User-scope CA trust (no admin / no sudo required) ---
 
-# Trust the proxy CA for the current user only (no sudo, no admin).
-# Use this for a zero-admin setup, e.g. VS Code users without root.
+# Trust the proxy CA for the current user only. No sudo required.
+# May prompt for keychain password. For zero-admin setup, e.g. VS Code users without root.
 import-ca-macos-user:
+	@if [ -z "$(CA_CERT)" ] || [ ! -f "$(CA_CERT)" ]; then \
+		echo "CA_CERT not found at '$(CA_CERT)'. Generate it first with 'make gen-ca'."; \
+		exit 1; \
+	fi
 	security add-trusted-cert -d -r trustRoot \
-		-k "$(HOME)/Library/Keychains/login.keychain-db" $(CA_CERT)
+		-k "$(HOME)/Library/Keychains/login.keychain-db" "$(CA_CERT)"
 	@echo "CA trusted on macOS (current user)."
 
 # Linux has no user-writable system CA store. Set NODE_EXTRA_CA_CERTS,
@@ -117,7 +121,6 @@ import-ca-linux-user:
 # Uses Cert:\CurrentUser\Root instead of Cert:\LocalMachine\Root.
 import-ca-windows-user:
 	powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/import-ca.ps1 -CaPath "$(CA_CERT)" -Scope User
-	@echo "CA trusted on Windows (current user)."
 
 # Quick smoke test against a running proxy
 smoke:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_FLAGS := -ldflags="-s -w"
 CA_CERT    := ca-cert.pem
 CA_KEY     := ca-key.pem
 
-.PHONY: all build run clean test lint security vulncheck check benchmark gen-ca import-ca-macos import-ca-linux import-ca-windows deploy
+.PHONY: all build run clean test lint security vulncheck check benchmark gen-ca import-ca-macos import-ca-linux import-ca-windows import-ca-macos-user import-ca-linux-user import-ca-windows-user deploy
 
 all: build
 
@@ -93,6 +93,31 @@ import-ca-linux:
 import-ca-windows:
 	@test -n "$(CA_CERT)" || { echo "Error: CA_CERT is not set. Run 'make generate-ca' first or set CA_CERT=path/to/ca.pem."; exit 1; }
 	powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/import-ca.ps1 -CaPath "$(CA_CERT)"
+
+# --- User-scope CA trust (no admin / no sudo required) ---
+
+# Trust the proxy CA for the current user only (no sudo, no admin).
+# Use this for a zero-admin setup, e.g. VS Code users without root.
+import-ca-macos-user:
+	security add-trusted-cert -d -r trustRoot \
+		-k "$(HOME)/Library/Keychains/login.keychain-db" $(CA_CERT)
+	@echo "CA trusted on macOS (current user)."
+
+# Linux has no user-writable system CA store. Set NODE_EXTRA_CA_CERTS,
+# REQUESTS_CA_BUNDLE, and SSL_CERT_FILE via a guided installer instead.
+# Writes ~/.config/environment.d/ai-proxy.conf + optional shell rc.
+import-ca-linux-user:
+	@if [ -z "$(CA_CERT)" ] || [ ! -f "$(CA_CERT)" ]; then \
+		echo "CA_CERT not found at '$(CA_CERT)'. Generate it first with 'make gen-ca'."; \
+		exit 1; \
+	fi
+	scripts/setup-user-env-linux.sh --ca-path "$(CA_CERT)"
+
+# Trust the proxy CA for the current Windows user (no admin).
+# Uses Cert:\CurrentUser\Root instead of Cert:\LocalMachine\Root.
+import-ca-windows-user:
+	powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/import-ca.ps1 -CaPath "$(CA_CERT)" -Scope User
+	@echo "CA trusted on Windows (current user)."
 
 # Quick smoke test against a running proxy
 smoke:

--- a/scripts/import-ca.ps1
+++ b/scripts/import-ca.ps1
@@ -2,21 +2,42 @@
 .SYNOPSIS
     Import the AI Proxy CA certificate into the Windows trust store.
 .DESCRIPTION
-    Adds the specified CA certificate to Cert:\LocalMachine\Root so that
-    TLS connections through the MITM proxy are trusted system-wide.
-    Requires Administrator privileges. Typically invoked via
-    `make import-ca-windows` from an elevated shell, but can also be run
-    directly in an elevated PowerShell session.
+    Adds the specified CA certificate to the Windows certificate store so
+    that TLS connections through the MITM proxy are trusted.
+
+    Two scopes are supported:
+
+      -Scope Machine  (default)
+        Installs to Cert:\LocalMachine\Root — system-wide trust.
+        Requires Administrator privileges.
+        Invoked via `make import-ca-windows`.
+
+      -Scope User
+        Installs to Cert:\CurrentUser\Root — current-user trust only.
+        No elevation required.
+        Invoked via `make import-ca-windows-user`.
+
     Accepts PEM or DER encoded certificates. PEM files are automatically
     converted to DER before import.
 .PARAMETER CaPath
     Path to the CA certificate file (PEM or DER).
+.PARAMETER Scope
+    Target certificate store scope: Machine (default) or User.
+.EXAMPLE
+    .\import-ca.ps1 -CaPath ca-cert.pem
+    # Imports to LocalMachine\Root (requires elevation)
+.EXAMPLE
+    .\import-ca.ps1 -CaPath ca-cert.pem -Scope User
+    # Imports to CurrentUser\Root (no elevation required)
 #>
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [string]$CaPath
+    [string]$CaPath,
+
+    [ValidateSet('Machine', 'User')]
+    [string]$Scope = 'Machine'
 )
 
 Set-StrictMode -Version Latest
@@ -29,13 +50,19 @@ if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
     exit 1
 }
 
-# Elevation check — fail cleanly rather than self-elevating
-$identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
-$principal = [Security.Principal.WindowsPrincipal]$identity
-if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    Write-Error "This target must be run from an elevated PowerShell prompt (Run as Administrator)."
-    exit 1
+# Elevation check — only required for Machine scope
+if ($Scope -eq 'Machine') {
+    $identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]$identity
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Write-Error "Machine scope requires an elevated PowerShell prompt (Run as Administrator). Use -Scope User for current-user trust without elevation."
+        exit 1
+    }
 }
+
+# Determine cert store location based on scope
+$certStoreLocation = if ($Scope -eq 'User') { 'Cert:\CurrentUser\Root' } else { 'Cert:\LocalMachine\Root' }
+$scopeLabel = if ($Scope -eq 'User') { 'current user' } else { 'all users' }
 
 # Read the certificate file — convert PEM to DER if needed
 $rawContent = [System.IO.File]::ReadAllText($resolvedPath).TrimStart([char]0xFEFF)
@@ -60,26 +87,26 @@ if ($rawContent -match '-----BEGIN CERTIFICATE-----') {
 try {
     # Idempotency check — skip if already trusted
     $incoming = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($importPath)
-    $existing = Get-ChildItem 'Cert:\LocalMachine\Root' | Where-Object {
+    $existing = Get-ChildItem $certStoreLocation | Where-Object {
         $_.Thumbprint -eq $incoming.Thumbprint
     }
     if ($existing) {
-        Write-Output "CA already trusted on Windows (thumbprint: $($existing.Thumbprint))."
+        Write-Output "CA already trusted on Windows for $scopeLabel (thumbprint: $($existing.Thumbprint))."
         exit 0
     }
 
     # Import and verify
-    $cert = Import-Certificate -FilePath $importPath -CertStoreLocation 'Cert:\LocalMachine\Root'
+    $cert = Import-Certificate -FilePath $importPath -CertStoreLocation $certStoreLocation
     if (-not $cert) {
         Write-Error "Import-Certificate completed but returned no certificate object."
         exit 1
     }
-    $installed = Get-ChildItem 'Cert:\LocalMachine\Root' | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+    $installed = Get-ChildItem $certStoreLocation | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
     if (-not $installed) {
         Write-Error "Certificate not found in store after import — Group Policy or security software may have blocked it."
         exit 1
     }
-    Write-Output "CA trusted on Windows (thumbprint: $($cert.Thumbprint))."
+    Write-Output "CA trusted on Windows for $scopeLabel (thumbprint: $($cert.Thumbprint))."
 } catch {
     Write-Error "Failed to import CA certificate: $_"
     exit 1

--- a/scripts/setup-user-env-linux.sh
+++ b/scripts/setup-user-env-linux.sh
@@ -2,8 +2,8 @@
 # setup-user-env-linux.sh — guided installer for per-user CA trust env vars.
 #
 # Linux has no user-writable system CA store. This script sets the three
-# environment variables that most runtimes (Node.js, Python/requests, curl,
-# Go) honour for custom CA bundles:
+# environment variables that most runtimes (Node.js, Python/requests, curl)
+# and indirectly Go (via SSL_CERT_FILE) honour for custom CA bundles:
 #
 #   NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, SSL_CERT_FILE
 #
@@ -36,7 +36,7 @@ USAGE:
   setup-user-env-linux.sh --help
 
 OPTIONS:
-  --ca-path <path>   Absolute path to the CA certificate (required).
+  --ca-path <path>   Path to the CA certificate (resolved to absolute).
   --dry-run          Print intended changes without writing anything.
   --yes, -y          Non-interactive — apply all recommended changes.
   --help, -h         Show this help and exit.
@@ -60,6 +60,9 @@ USAGE
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --ca-path)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --ca-path requires a value." >&2; exit 1
+            fi
             CA_PATH="$2"
             shift 2
             ;;
@@ -89,13 +92,14 @@ if [[ -z "$CA_PATH" ]]; then
     exit 1
 fi
 
-# Resolve to absolute path
-CA_PATH="$(cd "$(dirname "$CA_PATH")" && pwd)/$(basename "$CA_PATH")"
-
+# Check existence before resolving (avoids cryptic cd error for bad directories)
 if [[ ! -f "$CA_PATH" ]]; then
     echo "Error: CA certificate not found: $CA_PATH" >&2
     exit 1
 fi
+
+# Resolve to absolute path
+CA_PATH="$(cd "$(dirname "$CA_PATH")" && pwd)/$(basename "$CA_PATH")"
 
 # --- Helpers ---
 confirm() {
@@ -122,7 +126,7 @@ step1_env_conf() {
     echo ""
 
     if [[ -f "$ENV_FILE" ]]; then
-        existing_path=$(grep -oP '(?<=NODE_EXTRA_CA_CERTS=).*' "$ENV_FILE" 2>/dev/null || true)
+        existing_path=$(sed -n 's/^NODE_EXTRA_CA_CERTS=//p' "$ENV_FILE" 2>/dev/null || true)
         if [[ "$existing_path" == "$CA_PATH" ]]; then
             echo "Already set up with the same CA path. Skipping."
             return
@@ -162,7 +166,7 @@ step1_env_conf() {
     CHANGED_FILES+=("$ENV_FILE")
 }
 
-# --- Step 2 & 3: Shell rc ---
+# --- Step 2: Shell rc ---
 detect_shell_target() {
     local shell_name
     shell_name="$(basename "${SHELL:-}")"
@@ -211,10 +215,35 @@ step2_shell_rc() {
     echo "Target: $target"
     echo ""
 
-    # Idempotence check
+    # Idempotence check — also detect stale CA path
     if [[ -f "$target" ]] && grep -qF "$MARKER" "$target"; then
-        echo "Marker already present in $target. Skipping."
-        return
+        if [[ "$shell_name" == "fish" ]]; then
+            existing_rc_path=$(sed -n 's/^set -gx NODE_EXTRA_CA_CERTS "\(.*\)"/\1/p' "$target" 2>/dev/null || true)
+        else
+            existing_rc_path=$(sed -n 's/^export NODE_EXTRA_CA_CERTS="\(.*\)"/\1/p' "$target" 2>/dev/null || true)
+        fi
+        if [[ "$existing_rc_path" == "$CA_PATH" ]]; then
+            echo "Marker already present in $target with correct CA path. Skipping."
+            return
+        fi
+        echo "Marker present in $target but with a different CA path:"
+        echo "  Current:  $existing_rc_path"
+        echo "  Proposed: $CA_PATH"
+        echo ""
+        if $DRY_RUN; then
+            echo "[dry-run] Would replace CA path block in $target"
+            return
+        fi
+        if ! confirm "Replace the existing block?"; then
+            echo "Skipped."
+            return
+        fi
+        # Remove old block (marker line + next 3 export/set lines) and re-append
+        if [[ "$shell_name" == "fish" ]]; then
+            sed -i.bak "/$MARKER/,+3d" "$target" && rm -f "$target.bak"
+        else
+            sed -i.bak "/$MARKER/,+3d" "$target" && rm -f "$target.bak"
+        fi
     fi
 
     local block

--- a/scripts/setup-user-env-linux.sh
+++ b/scripts/setup-user-env-linux.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# setup-user-env-linux.sh — guided installer for per-user CA trust env vars.
+#
+# Linux has no user-writable system CA store. This script sets the three
+# environment variables that most runtimes (Node.js, Python/requests, curl,
+# Go) honour for custom CA bundles:
+#
+#   NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, SSL_CERT_FILE
+#
+# Targets:
+#   ~/.config/environment.d/ai-proxy.conf  (always — picked up by systemd)
+#   Shell rc file (opt-in — detected from $SHELL)
+#
+# Usage:
+#   setup-user-env-linux.sh --ca-path /path/to/ca-cert.pem
+#   setup-user-env-linux.sh --ca-path /path/to/ca-cert.pem --dry-run
+#   setup-user-env-linux.sh --ca-path /path/to/ca-cert.pem --yes
+#   setup-user-env-linux.sh --help
+
+set -euo pipefail
+
+# --- Defaults ---
+CA_PATH=""
+DRY_RUN=false
+YES=false
+MARKER="# ai-anonymizing-proxy — user CA trust"
+CHANGED_FILES=()
+
+# --- Usage ---
+usage() {
+    cat <<'USAGE'
+setup-user-env-linux.sh — set per-user CA trust env vars for the AI proxy.
+
+USAGE:
+  setup-user-env-linux.sh --ca-path <path> [--dry-run] [--yes]
+  setup-user-env-linux.sh --help
+
+OPTIONS:
+  --ca-path <path>   Absolute path to the CA certificate (required).
+  --dry-run          Print intended changes without writing anything.
+  --yes, -y          Non-interactive — apply all recommended changes.
+  --help, -h         Show this help and exit.
+
+TARGETS:
+  ~/.config/environment.d/ai-proxy.conf
+      Sets NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, SSL_CERT_FILE.
+      Picked up by systemd user sessions on next login.
+
+  Shell rc (detected from $SHELL):
+      bash  → ~/.bashrc
+      zsh   → ~/.zshrc
+      fish  → ~/.config/fish/conf.d/ai-proxy.fish
+
+After running, log out and back in (or source the shell rc) for changes
+to take effect in new terminals.
+USAGE
+}
+
+# --- Argument parsing ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ca-path)
+            CA_PATH="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --yes|-y)
+            YES=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$CA_PATH" ]]; then
+    echo "Error: --ca-path is required." >&2
+    echo "Run with --help for usage." >&2
+    exit 1
+fi
+
+# Resolve to absolute path
+CA_PATH="$(cd "$(dirname "$CA_PATH")" && pwd)/$(basename "$CA_PATH")"
+
+if [[ ! -f "$CA_PATH" ]]; then
+    echo "Error: CA certificate not found: $CA_PATH" >&2
+    exit 1
+fi
+
+# --- Helpers ---
+confirm() {
+    if $YES; then
+        return 0
+    fi
+    local prompt="$1 [y/N] "
+    local reply
+    read -rp "$prompt" reply
+    [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+# --- Step 1: ~/.config/environment.d/ai-proxy.conf ---
+ENV_DIR="$HOME/.config/environment.d"
+ENV_FILE="$ENV_DIR/ai-proxy.conf"
+ENV_CONTENT="NODE_EXTRA_CA_CERTS=$CA_PATH
+REQUESTS_CA_BUNDLE=$CA_PATH
+SSL_CERT_FILE=$CA_PATH"
+
+step1_env_conf() {
+    echo ""
+    echo "=== Step 1: systemd environment.d ==="
+    echo "Target: $ENV_FILE"
+    echo ""
+
+    if [[ -f "$ENV_FILE" ]]; then
+        existing_path=$(grep -oP '(?<=NODE_EXTRA_CA_CERTS=).*' "$ENV_FILE" 2>/dev/null || true)
+        if [[ "$existing_path" == "$CA_PATH" ]]; then
+            echo "Already set up with the same CA path. Skipping."
+            return
+        fi
+        echo "File exists with a different CA path:"
+        echo "  Current:  $existing_path"
+        echo "  Proposed: $CA_PATH"
+        echo ""
+        echo "Proposed content:"
+        echo "$ENV_CONTENT"
+        echo ""
+        if $DRY_RUN; then
+            echo "[dry-run] Would overwrite $ENV_FILE"
+            return
+        fi
+        if ! confirm "Overwrite $ENV_FILE?"; then
+            echo "Skipped."
+            return
+        fi
+    else
+        echo "Proposed content:"
+        echo "$ENV_CONTENT"
+        echo ""
+        if $DRY_RUN; then
+            echo "[dry-run] Would create $ENV_FILE"
+            return
+        fi
+        if ! confirm "Create $ENV_FILE?"; then
+            echo "Skipped."
+            return
+        fi
+    fi
+
+    mkdir -p "$ENV_DIR"
+    printf '%s\n' "$ENV_CONTENT" > "$ENV_FILE"
+    echo "Written: $ENV_FILE"
+    CHANGED_FILES+=("$ENV_FILE")
+}
+
+# --- Step 2 & 3: Shell rc ---
+detect_shell_target() {
+    local shell_name
+    shell_name="$(basename "${SHELL:-}")"
+    case "$shell_name" in
+        bash) echo "$HOME/.bashrc" ;;
+        zsh)  echo "$HOME/.zshrc" ;;
+        fish) echo "$HOME/.config/fish/conf.d/ai-proxy.fish" ;;
+        *)    echo "" ;;
+    esac
+}
+
+shell_block_posix() {
+    cat <<EOF
+$MARKER
+export NODE_EXTRA_CA_CERTS="$CA_PATH"
+export REQUESTS_CA_BUNDLE="$CA_PATH"
+export SSL_CERT_FILE="$CA_PATH"
+EOF
+}
+
+shell_block_fish() {
+    cat <<EOF
+$MARKER
+set -gx NODE_EXTRA_CA_CERTS "$CA_PATH"
+set -gx REQUESTS_CA_BUNDLE "$CA_PATH"
+set -gx SSL_CERT_FILE "$CA_PATH"
+EOF
+}
+
+step2_shell_rc() {
+    echo ""
+    echo "=== Step 2: Shell rc ==="
+
+    local shell_name
+    shell_name="$(basename "${SHELL:-}")"
+    local target
+    target="$(detect_shell_target)"
+
+    if [[ -z "$target" ]]; then
+        echo "Warning: unrecognised shell '$shell_name'. Skipping shell rc setup."
+        echo "You can manually export the env vars in your shell config."
+        return
+    fi
+
+    echo "Detected shell: $shell_name"
+    echo "Target: $target"
+    echo ""
+
+    # Idempotence check
+    if [[ -f "$target" ]] && grep -qF "$MARKER" "$target"; then
+        echo "Marker already present in $target. Skipping."
+        return
+    fi
+
+    local block
+    if [[ "$shell_name" == "fish" ]]; then
+        block="$(shell_block_fish)"
+    else
+        block="$(shell_block_posix)"
+    fi
+
+    echo "Proposed block:"
+    echo "$block"
+    echo ""
+
+    if $DRY_RUN; then
+        if [[ "$shell_name" == "fish" ]]; then
+            echo "[dry-run] Would create $target"
+        else
+            echo "[dry-run] Would append to $target"
+        fi
+        return
+    fi
+
+    if ! confirm "Apply?"; then
+        echo "Skipped."
+        return
+    fi
+
+    if [[ "$shell_name" == "fish" ]]; then
+        mkdir -p "$(dirname "$target")"
+        printf '%s\n' "$block" > "$target"
+        echo "Written: $target"
+    else
+        printf '\n%s\n' "$block" >> "$target"
+        echo "Appended to: $target"
+    fi
+    CHANGED_FILES+=("$target")
+}
+
+# --- Run ---
+step1_env_conf
+step2_shell_rc
+
+# --- Summary ---
+echo ""
+echo "=== Summary ==="
+if $DRY_RUN; then
+    echo "Dry run complete. No files were modified."
+else
+    if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+        echo "No changes were made (already set up or skipped)."
+    else
+        echo "Files changed:"
+        for f in "${CHANGED_FILES[@]}"; do
+            echo "  $f"
+        done
+        echo ""
+        echo "Log out and back in, or source your shell rc, for changes to take effect."
+    fi
+fi


### PR DESCRIPTION
Adds a zero-admin, user-scope CA trust flow alongside the existing admin-required one. Ships code only — docs for this feature plus the pre-existing cross-OS parity findings land in a follow-up docs PR.

## What's new

- `scripts/import-ca.ps1` gains `-Scope User` → `Cert:\CurrentUser\Root`, no elevation required.
- `scripts/setup-user-env-linux.sh` — guided installer for the three CA env vars (`NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`) into `~/.config/environment.d/ai-proxy.conf` and the user's shell rc. Supports `--dry-run` and `--yes`.
- Three new Makefile targets: `import-ca-macos-user`, `import-ca-linux-user`, `import-ca-windows-user`.

## Rationale for Linux being different

Linux has no user-writable equivalent of `/usr/local/share/ca-certificates/`. The standards-compliant user-scope path is to set the three env vars — which Node.js, Python/requests, curl, and most Go binaries respect.

## Why no docs in this PR

The docs for this feature land in a follow-up PR alongside the cross-OS parity fixes identified in an earlier audit. Each new Makefile target has an inline comment; both scripts support `--help`. No doc surface is changed in this PR.

## Testing

- All three Makefile targets verified via `make -n` expansion
- `setup-user-env-linux.sh` verified via `--help`, missing-arg error path, and `--dry-run`. Real writes not exercised in the development environment (sandbox blocks home-directory writes by design).
- `shellcheck scripts/setup-user-env-linux.sh` — passed (0 issues)
- PowerShell AST parse via `[System.Management.Automation.Language.Parser]::ParseFile` — passed
- `Invoke-ScriptAnalyzer -EnableExit` on `import-ca.ps1` — passed (baseline preserved after `-Scope` extension)
- `make lint` — passed (0 issues)
- **Not executed on a live Windows host.** Manual verification required before merge.