### PR TITLE
ci(dependabot): add Dependabot config [closes #95]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Add Dependabot configuration to automate dependency update PRs for Go modules and GitHub Actions.

## Changes

- New `.github/dependabot.yml` with two ecosystems:
  - `gomod` — weekly Go dependency updates
  - `github-actions` — weekly action SHA updates (complements SHA pinning from #19)

## Quality Gates

- [x] Config-only change — no code affected
- [x] Architecture invariants maintained

Closes #95