### PR TITLE
feat(anonymizer): provider-aware streaming deanonymizer interface [closes #52]

### DIFF
--- a/docs/anonymizer.md
+++ b/docs/anonymizer.md
@@ -133,8 +133,8 @@ sequenceDiagram
     API-->>P: response
 
     alt streaming (SSE)
-        P->>A: StreamingDeanonymize(body, sessionID)
-        Note over A: snapshot token map under read lock
+        P->>A: StreamingDeanonymize(body, sessionID, domain)
+        Note over A: snapshot token map, select provider for domain
         A-->>P: io.ReadCloser (tokens replaced on-the-fly)
     else buffered
         P->>A: DeanonymizeText(body, sessionID)
@@ -152,39 +152,47 @@ starts, so a `DeleteSession` call that races with streaming cannot cause missed 
 
 ## Streaming deanonymization
 
-The Anthropic API delivers one or two characters per `text_delta` SSE event, meaning a single
-token like `[PII_EMAIL_c160f8cc4b2e1a3d]` frequently arrives split across multiple events:
+AI API providers deliver streaming responses in different SSE formats. A token like
+`[PII_EMAIL_c160f8cc4b2e1a3d]` frequently arrives split across multiple SSE events, making raw
+byte replacement impossible. `StreamingDeanonymize` uses a provider-aware interface to handle
+each format correctly:
 
-```
-{"type":"text_delta","text":"[PII_EMA"}
-{"type":"text_delta","text":"IL_c160f8cc4b2e1a3d]"}
-```
+| Provider | Domains | SSE format | Text field |
+|----------|---------|------------|------------|
+| Anthropic | `api.anthropic.com` | `content_block_delta` events | `delta.text`, `delta.thinking`, `delta.partial_json` |
+| OpenAI | `api.openai.com`, `api.mistral.ai`, `api.together.xyz`, `api.perplexity.ai`, `api.huggingface.co` | `chat.completion.chunk` | `choices[0].delta.content` |
+| Gemini | `generativelanguage.googleapis.com` | `GenerateContentResponse` | `candidates[0].content.parts[0].text` |
+| Cohere | `api.cohere.ai` | `content-delta` events | `delta.message.content.text` |
+| Replicate | `api.replicate.com` | Plain text SSE | `data` field (plain text) |
+| Passthrough | Unknown domains | Raw replacement | Entire payload |
 
-Raw byte replacement cannot match tokens split this way. `StreamingDeanonymize` delegates to a
-pipeline of small helper functions (in `streaming.go`) that each handle one concern:
+The `StreamingDeanonymizer` interface has two methods:
+
+- `ProcessDataPayload(payload []byte) bool` — handles the bytes after `data: ` in an SSE line.
+  Returns `true` if handled, `false` to fall back to raw token replacement.
+- `Flush()` — emits any remaining accumulated text at stream end.
+
+The shared framework (`streaming.go`) handles concerns common to all providers:
 
 1. **Line assembly** (`readLoop` → `assembleLines`) — reads raw bytes from the source, splits
    on newlines, strips `\r`, and dispatches complete lines.
 2. **Line classification** (`processLine`) — routes each SSE line: comments and empty lines
-   pass through verbatim; non-`data:` lines go through the replacer; `data:` lines are parsed
-   as JSON.
-3. **Text accumulation** (`processTextDelta`) — accumulates text across consecutive
-   `content_block_delta` / `text_delta` **and** `thinking_delta` events, tracks the content
-   block index, and flushes safe prefixes.
-4. **Safe flush boundary** (`safeCutPoint`) — calculates how many accumulated bytes can be
+   pass through verbatim; non-`data:` lines go through the replacer; `data:` lines are
+   delegated to the provider's `ProcessDataPayload`.
+3. **Safe flush boundary** (`safeCutPoint`) — calculates how many accumulated bytes can be
    flushed without splitting a partial token. A `tokenSuffixLen` of 33 bytes is retained in
    the accumulator — enough to cover the longest possible token
    (`[PII_CREDITCARD_XXXXXXXXXXXXXXXX]` = 33 chars).
-5. **Remainder flush** (`flushRemainder`) — when a non-text-delta event arrives or the stream
-   ends, any text still in the accumulator is emitted as a synthetic `content_block_delta`
-   targeting the correct content block index.
-6. **Stream end** (`handleStreamEnd`) — flushes partial lines and accumulated text at EOF or on
-   read error.
+4. **Stream end** (`handleStreamEnd`) — flushes partial lines and calls `provider.Flush()`
+   at EOF or on read error.
 
-A `streamContext` struct holds the shared mutable state for a single invocation: the pipe
-writer, replacer, text accumulator, last-seen content block index, and logging configuration.
-The replacer is applied on **all** passthrough paths (non-JSON lines, non-delta events, etc.)
-so tokens embedded anywhere in the SSE stream are deanonymized.
+Each provider implementation accumulates text fragments, applies `safeCutPoint` to determine
+safe flush boundaries, performs token replacement via the shared `strings.Replacer`, and
+re-serializes the output in the provider's native SSE format.
+
+A `streamContext` struct holds the shared framework state: the pipe writer, replacer, and
+provider instance. The replacer is applied on **all** passthrough paths (non-JSON lines,
+non-delta events, etc.) so tokens embedded anywhere in the SSE stream are deanonymized.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,7 +73,7 @@ sequenceDiagram
         P->>API: POST /v1/messages (anonymized, real TLS)
         API-->>P: response
         alt SSE / text/event-stream
-            P->>A: StreamingDeanonymize(body, sessionID)
+            P->>A: StreamingDeanonymize(body, sessionID, domain)
             A-->>C: token replacements streamed on-the-fly
         else buffered response
             P->>A: DeanonymizeText(body, sessionID)
@@ -235,26 +235,33 @@ Each request gets a random `sessionID`. The token→original map is stored in
 `anonymizer.sessions[sessionID]` during anonymization and deleted after the response is delivered.
 
 For SSE (`Content-Type: text/event-stream`), `StreamingDeanonymize` wraps the response body in a
-pipe-based reader. Because the Anthropic API delivers one or two characters per `text_delta`
-event, a single token like `[PII_EMAIL_c160f8cc4b2e1a3d]` frequently arrives split across multiple
-events.
+pipe-based reader. AI API providers deliver text content in different SSE formats, and a single
+token like `[PII_EMAIL_c160f8cc4b2e1a3d]` frequently arrives split across multiple events.
 
-The streaming logic is decomposed into small, independently testable helpers in
-`internal/anonymizer/streaming.go`:
+The streaming system uses a provider-aware `StreamingDeanonymizer` interface to handle each
+provider's SSE format. The `domain` parameter selects the appropriate implementation:
+
+| Provider | Text field | Domains |
+|----------|------------|---------|
+| Anthropic | `delta.text` / `delta.thinking` | `api.anthropic.com` |
+| OpenAI | `choices[0].delta.content` | `api.openai.com`, `api.mistral.ai`, `api.together.xyz`, `api.perplexity.ai`, `api.huggingface.co` |
+| Gemini | `candidates[0].content.parts[0].text` | `generativelanguage.googleapis.com` |
+| Cohere | `delta.message.content.text` | `api.cohere.ai` |
+| Replicate | Plain text in `data` | `api.replicate.com` |
+| Passthrough | Raw replacement | Unknown domains |
+
+The shared framework in `internal/anonymizer/streaming.go` handles SSE framing:
 
 | Helper | Responsibility |
 |---|---|
 | `readLoop` | Top-level goroutine: reads chunks from the source and dispatches complete lines |
 | `assembleLines` | Splits raw bytes on newlines, strips `\r`, dispatches to `processLine` |
-| `processLine` | Classifies each SSE line (comment, non-data, JSON data) and routes accordingly |
-| `processTextDelta` | Accumulates text across `text_delta` / `thinking_delta` events, flushes safe prefixes |
+| `processLine` | Classifies each SSE line (comment, non-data, data) and delegates data payloads to the provider |
 | `safeCutPoint` | Calculates how many accumulated bytes can be flushed without splitting a partial token |
-| `flushRemainder` | Emits a synthetic `content_block_delta` carrying any text still in the accumulator |
-| `handleStreamEnd` | Flushes partial lines and accumulated text at EOF or on read error |
+| `handleStreamEnd` | Flushes partial lines and calls `provider.Flush()` at EOF or on read error |
 
-A `streamContext` struct holds the mutable state shared across these helpers for a single
-streaming invocation, including the `lastIndex` field that tracks the most recently seen
-content block index so that flush events target the correct block (thinking vs. text).
+Provider-specific implementations live in separate files (`streaming_anthropic.go`,
+`streaming_openai.go`, etc.) and handle JSON parsing, text accumulation, and re-serialization.
 
 The 33-byte suffix guard (`tokenSuffixLen`) is retained in the accumulator — enough to cover
 the longest possible token (`[PII_CREDITCARD_XXXXXXXXXXXXXXXX]` = 33 chars). Non-delta events (ping,

--- a/internal/anonymizer/anonymizer.go
+++ b/internal/anonymizer/anonymizer.go
@@ -625,30 +625,23 @@ func (a *Anonymizer) DeleteSession(sessionID string) {
 }
 
 // StreamingDeanonymize wraps src in a reader that replaces PII tokens on-the-fly
-// for Anthropic SSE streams.
+// for provider-specific SSE streams.
 //
-// The Anthropic API streams one or two characters per text_delta event, which
-// means a single PII token like [PII_EMAIL_c160f8cc4b2e1a3d] frequently arrives split across
-// multiple SSE events:
+// AI API providers stream text content in different SSE formats. The domain
+// parameter selects the appropriate provider implementation:
+//   - api.anthropic.com: content_block_delta with text_delta/thinking_delta
+//   - api.openai.com (and compatible): choices[0].delta.content
+//   - generativelanguage.googleapis.com: candidates[0].content.parts[0].text
+//   - api.cohere.ai: content-delta with delta.message.content.text
+//   - api.replicate.com: plain text in data field
+//   - unknown domains: raw token replacement (passthrough)
 //
-//	{"type":"text_delta","text":"[PII_78cabb"}
-//	{"type":"text_delta","text":"39]"}
-//
-// Raw byte replacement on the SSE envelope cannot match tokens split this way.
-// This function therefore:
-//  1. Buffers incoming bytes line by line.
-//  2. For each complete "data: {...}" SSE line, parses the JSON.
-//  3. If the event is a content_block_delta / text_delta, it accumulates the
-//     text content into a per-stream text buffer.
-//  4. After each text_delta, it checks whether the accumulated buffer contains
-//     complete tokens and flushes any replaced text back into the JSON, re-
-//     serializing the SSE line before writing it downstream.
-//  5. Non-text-delta lines (ping, message_start, thinking_delta, etc.) are
-//     passed through verbatim.
+// Token splits across SSE events are handled by accumulating text fragments
+// and using safeCutPoint to determine safe flush boundaries.
 //
 // A snapshot of the session token map is taken immediately (under the read
 // lock) so the goroutine is unaffected by a later DeleteSession call.
-func (a *Anonymizer) StreamingDeanonymize(src io.ReadCloser, sessionID string) io.ReadCloser {
+func (a *Anonymizer) StreamingDeanonymize(src io.ReadCloser, sessionID string, domain string) io.ReadCloser {
 	a.sessionMu.RLock()
 	rawMap := a.sessions[sessionID]
 	tokenMap := make(map[string]string, len(rawMap))
@@ -675,12 +668,18 @@ func (a *Anonymizer) StreamingDeanonymize(src io.ReadCloser, sessionID string) i
 	replacer := strings.NewReplacer(pairs...)
 
 	pr, pw := io.Pipe()
-	ctx := &streamContext{
+	opts := streamDeanonymizerOpts{
 		pw:         pw,
 		replacer:   replacer,
 		sessionID:  sessionID,
 		verbose:    a.verbose,
 		tokenCount: len(tokenMap),
+	}
+	provider := NewStreamingDeanonymizer(ProviderForDomain(domain), opts)
+	ctx := &streamContext{
+		pw:       pw,
+		replacer: replacer,
+		provider: provider,
 	}
 	go readLoop(src, ctx)
 	return pr

--- a/internal/anonymizer/anonymizer_test.go
+++ b/internal/anonymizer/anonymizer_test.go
@@ -102,7 +102,7 @@ func TestStreamingDeanonymizeRoundTrip(t *testing.T) {
 	}
 
 	src := io.NopCloser(strings.NewReader(anonymized))
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck // test cleanup
 
 	got, err := io.ReadAll(rc)
@@ -120,7 +120,7 @@ func TestStreamingDeanonymizeNoTokens(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(text))
 	// session with no replacements: should get back the original reader unchanged
-	rc := a.StreamingDeanonymize(src, "empty-session")
+	rc := a.StreamingDeanonymize(src, "empty-session", "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck // test cleanup
 
 	got, err := io.ReadAll(rc)
@@ -670,7 +670,7 @@ func TestStreamingDeanonymizeChunkBoundary(t *testing.T) {
 	// Deliver the anonymized content one byte per Read to force every possible
 	// token split across chunk boundaries.
 	src := &bytewiseReader{data: []byte(anonymized)}
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck // test cleanup
 
 	got, err := io.ReadAll(rc)
@@ -1243,7 +1243,7 @@ func TestStreamingDeanonymizeWithMetrics(t *testing.T) {
 
 	sseInput := "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n"
 	src := io.NopCloser(strings.NewReader(sseInput))
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck
 	io.ReadAll(rc)   //nolint:errcheck
 

--- a/internal/anonymizer/bench_test.go
+++ b/internal/anonymizer/bench_test.go
@@ -164,7 +164,7 @@ func BenchmarkStreamingFlush(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		r := mockReadCloser{strings.NewReader(sseChunk)}
-		rc := a.StreamingDeanonymize(r, sessionID)
+		rc := a.StreamingDeanonymize(r, sessionID, "api.anthropic.com")
 		_, _ = io.Copy(io.Discard, rc)
 		_ = rc.Close()
 	}
@@ -184,7 +184,7 @@ func BenchmarkStreamingFlushNoTokens(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		r := mockReadCloser{strings.NewReader(sseChunk)}
-		rc := a.StreamingDeanonymize(r, sessionID)
+		rc := a.StreamingDeanonymize(r, sessionID, "api.anthropic.com")
 		_, _ = io.Copy(io.Discard, rc)
 		_ = rc.Close()
 	}
@@ -216,7 +216,7 @@ data: {"type":"content_block_delta","delta":{"type":"text_delta","text":" final 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		r := mockReadCloser{strings.NewReader(sseChunk)}
-		rc := a.StreamingDeanonymize(r, sessionID)
+		rc := a.StreamingDeanonymize(r, sessionID, "api.anthropic.com")
 		_, _ = io.Copy(io.Discard, rc)
 		_ = rc.Close()
 	}

--- a/internal/anonymizer/streaming.go
+++ b/internal/anonymizer/streaming.go
@@ -2,25 +2,10 @@ package anonymizer
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"log"
 	"strings"
 )
-
-// sseEnvelope is the minimal structure needed to identify text_delta events
-// in an Anthropic SSE stream.
-type sseEnvelope struct {
-	Type  string    `json:"type"`
-	Delta *sseDelta `json:"delta"`
-	Index int       `json:"index"`
-}
-
-type sseDelta struct {
-	Type        string `json:"type"`
-	Text        string `json:"text"`
-	PartialJSON string `json:"partial_json,omitempty"`
-}
 
 // tokenSuffixLen is the number of bytes kept unflushed in the streaming
 // accumulator to guard against partial token splits. The longest possible
@@ -59,137 +44,28 @@ func safeCutPoint(accumulated string) int {
 	return cutAt
 }
 
-// streamContext holds the mutable state shared by the streaming helper
+// streamContext holds the mutable state shared by the streaming framework
 // functions during a single StreamingDeanonymize invocation.
 type streamContext struct {
-	pw            *io.PipeWriter
-	replacer      *strings.Replacer
-	textAccum     strings.Builder
-	jsonAccum     strings.Builder
-	lastIndex     int // content block index from the most recent text_delta
-	lastJSONIndex int // content block index from the most recent input_json_delta
-	sessionID     string
-	verbose       bool
-	tokenCount    int
+	pw       *io.PipeWriter
+	replacer *strings.Replacer
+	provider StreamingDeanonymizer
 }
 
-// processTextDelta handles a text_delta or thinking_delta SSE event by
-// accumulating text and flushing safe prefixes with token replacement.
-func processTextDelta(ctx *streamContext, envelope *sseEnvelope) error {
-	ctx.lastIndex = envelope.Index
-	ctx.textAccum.WriteString(envelope.Delta.Text)
-	accumulated := ctx.textAccum.String()
-
-	flushUpTo := safeCutPoint(accumulated)
-	if flushUpTo == 0 {
-		return nil
-	}
-
-	toReplace := accumulated[:flushUpTo]
-	replaced := ctx.replacer.Replace(toReplace)
-	if toReplace != replaced && ctx.verbose {
-		log.Printf("[DEANON] text replaced: sessionID=%s tokens=%d", ctx.sessionID, ctx.tokenCount)
-	}
-
-	envelope.Delta.Text = replaced
-	newPayload, err := json.Marshal(envelope)
-	if err != nil {
-		return err
-	}
-
-	ctx.pw.Write([]byte(sseDataPrefix)) //nolint:errcheck
-	ctx.pw.Write(newPayload)            //nolint:errcheck
-	ctx.pw.Write([]byte("\n"))          //nolint:errcheck
-
-	remaining := accumulated[flushUpTo:]
-	ctx.textAccum.Reset()
-	ctx.textAccum.WriteString(remaining)
-	return nil
-}
-
-// flushRemainder emits a synthetic content_block_delta carrying any text
-// still held in the accumulator, with token replacement applied.
-func flushRemainder(ctx *streamContext) {
-	if ctx.textAccum.Len() == 0 {
-		return
-	}
-	flushed := ctx.replacer.Replace(ctx.textAccum.String())
-	if flushed != "" {
-		// Use the last-seen content block index so that thinking (index 0)
-		// and text (index 1) blocks flush to their correct position.
-		synth := map[string]any{
-			"type":  "content_block_delta",
-			"index": ctx.lastIndex,
-			"delta": map[string]string{"type": "text_delta", "text": flushed},
-		}
-		if b, err := json.Marshal(synth); err == nil {
-			ctx.pw.Write([]byte(sseDataPrefix)) //nolint:errcheck
-			ctx.pw.Write(b)                     //nolint:errcheck
-			ctx.pw.Write([]byte("\n\n"))        //nolint:errcheck
+// writePipe writes multiple byte slices to a PipeWriter, stopping on the
+// first error. A write error means the reader side has been closed (client
+// disconnected); continuing to write would be wasteful.
+func writePipe(pw *io.PipeWriter, parts ...[]byte) {
+	for _, p := range parts {
+		if _, err := pw.Write(p); err != nil {
+			return
 		}
 	}
-	ctx.textAccum.Reset()
-}
-
-// processJSONDelta handles an input_json_delta SSE event by accumulating
-// partial_json fragments and flushing safe prefixes with token replacement.
-func processJSONDelta(ctx *streamContext, envelope *sseEnvelope) error {
-	ctx.lastJSONIndex = envelope.Index
-	ctx.jsonAccum.WriteString(envelope.Delta.PartialJSON)
-	accumulated := ctx.jsonAccum.String()
-
-	flushUpTo := safeCutPoint(accumulated)
-	if flushUpTo == 0 {
-		return nil
-	}
-
-	toReplace := accumulated[:flushUpTo]
-	replaced := ctx.replacer.Replace(toReplace)
-	if toReplace != replaced && ctx.verbose {
-		log.Printf("[DEANON] json replaced: sessionID=%s tokens=%d", ctx.sessionID, ctx.tokenCount)
-	}
-
-	envelope.Delta.PartialJSON = replaced
-	newPayload, err := json.Marshal(envelope)
-	if err != nil {
-		return err
-	}
-
-	ctx.pw.Write([]byte(sseDataPrefix)) //nolint:errcheck
-	ctx.pw.Write(newPayload)            //nolint:errcheck
-	ctx.pw.Write([]byte("\n"))          //nolint:errcheck
-
-	remaining := accumulated[flushUpTo:]
-	ctx.jsonAccum.Reset()
-	ctx.jsonAccum.WriteString(remaining)
-	return nil
-}
-
-// flushJSONRemainder emits a synthetic content_block_delta carrying any
-// partial_json still held in the JSON accumulator, with token replacement.
-func flushJSONRemainder(ctx *streamContext) {
-	if ctx.jsonAccum.Len() == 0 {
-		return
-	}
-	flushed := ctx.replacer.Replace(ctx.jsonAccum.String())
-	if flushed != "" {
-		synth := map[string]any{
-			"type":  "content_block_delta",
-			"index": ctx.lastJSONIndex,
-			"delta": map[string]string{"type": "input_json_delta", "partial_json": flushed},
-		}
-		if b, err := json.Marshal(synth); err == nil {
-			ctx.pw.Write([]byte(sseDataPrefix)) //nolint:errcheck
-			ctx.pw.Write(b)                     //nolint:errcheck
-			ctx.pw.Write([]byte("\n\n"))        //nolint:errcheck
-		}
-	}
-	ctx.jsonAccum.Reset()
 }
 
 // processLine handles one complete SSE line (without trailing newline).
-// It dispatches text_delta events to processTextDelta, flushes accumulated
-// text on non-text-delta events, and passes through non-data lines.
+// It delegates data payloads to the provider-specific StreamingDeanonymizer
+// and passes through non-data lines with raw token replacement.
 func processLine(ctx *streamContext, line []byte) {
 	if len(line) == 0 || line[0] == ':' {
 		ctx.pw.Write(line)         //nolint:errcheck
@@ -204,45 +80,12 @@ func processLine(ctx *streamContext, line []byte) {
 	}
 
 	payload := line[len(sseDataPrefix):]
-
-	var envelope sseEnvelope
-	if err := json.Unmarshal(payload, &envelope); err != nil {
+	if !ctx.provider.ProcessDataPayload(payload) {
+		// Provider could not parse the payload — fall back to raw replacement.
 		ctx.pw.Write([]byte(sseDataPrefix))                         //nolint:errcheck
 		ctx.pw.Write([]byte(ctx.replacer.Replace(string(payload)))) //nolint:errcheck
 		ctx.pw.Write([]byte("\n"))                                  //nolint:errcheck
-		return
 	}
-
-	isDeltaText := envelope.Type == "content_block_delta" &&
-		envelope.Delta != nil &&
-		(envelope.Delta.Type == "text_delta" || envelope.Delta.Type == "thinking_delta")
-
-	isJSONDelta := envelope.Type == "content_block_delta" &&
-		envelope.Delta != nil &&
-		envelope.Delta.Type == "input_json_delta"
-
-	if isDeltaText {
-		if err := processTextDelta(ctx, &envelope); err != nil {
-			ctx.pw.Write(line)         //nolint:errcheck
-			ctx.pw.Write([]byte("\n")) //nolint:errcheck
-			ctx.textAccum.Reset()
-		}
-		return
-	}
-
-	if isJSONDelta {
-		if err := processJSONDelta(ctx, &envelope); err != nil {
-			ctx.pw.Write(line)         //nolint:errcheck
-			ctx.pw.Write([]byte("\n")) //nolint:errcheck
-			ctx.jsonAccum.Reset()
-		}
-		return
-	}
-
-	flushRemainder(ctx)
-	flushJSONRemainder(ctx)
-	ctx.pw.Write([]byte(ctx.replacer.Replace(string(line)))) //nolint:errcheck
-	ctx.pw.Write([]byte("\n"))                               //nolint:errcheck
 }
 
 // assembleLines processes raw bytes from a read chunk, appending them to
@@ -264,14 +107,13 @@ func assembleLines(chunk []byte, lineBuf []byte, ctx *streamContext) []byte {
 	return lineBuf
 }
 
-// handleStreamEnd flushes any partial line and accumulated text when the
-// source reader returns an error (including io.EOF).
+// handleStreamEnd flushes any partial line and the provider's accumulated
+// text when the source reader returns an error (including io.EOF).
 func handleStreamEnd(lineBuf []byte, readErr error, ctx *streamContext) {
 	if len(lineBuf) > 0 {
 		ctx.pw.Write([]byte(ctx.replacer.Replace(string(lineBuf)))) //nolint:errcheck
 	}
-	flushRemainder(ctx)
-	flushJSONRemainder(ctx)
+	ctx.provider.Flush()
 	if readErr != io.EOF {
 		log.Printf("[ANONYMIZER] StreamingDeanonymize read error: %v", readErr)
 		ctx.pw.CloseWithError(readErr) //nolint:errcheck

--- a/internal/anonymizer/streaming_anthropic.go
+++ b/internal/anonymizer/streaming_anthropic.go
@@ -1,0 +1,173 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+)
+
+// sseEnvelope is the minimal structure needed to identify text_delta events
+// in an Anthropic SSE stream.
+type sseEnvelope struct {
+	Type  string    `json:"type"`
+	Delta *sseDelta `json:"delta"`
+	Index int       `json:"index"`
+}
+
+type sseDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	PartialJSON string `json:"partial_json,omitempty"`
+}
+
+// anthropicDeanonymizer handles Anthropic's SSE format: content_block_delta
+// events with text_delta, thinking_delta, and input_json_delta sub-types.
+type anthropicDeanonymizer struct {
+	opts          streamDeanonymizerOpts
+	textAccum     strings.Builder
+	jsonAccum     strings.Builder
+	lastIndex     int // content block index from the most recent text_delta
+	lastJSONIndex int // content block index from the most recent input_json_delta
+}
+
+func newAnthropicDeanonymizer(opts streamDeanonymizerOpts) *anthropicDeanonymizer {
+	return &anthropicDeanonymizer{opts: opts}
+}
+
+// ProcessDataPayload parses an Anthropic SSE JSON payload and dispatches
+// to the appropriate accumulator.
+func (a *anthropicDeanonymizer) ProcessDataPayload(payload []byte) bool {
+	var envelope sseEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return false
+	}
+
+	isDeltaText := envelope.Type == "content_block_delta" &&
+		envelope.Delta != nil &&
+		(envelope.Delta.Type == "text_delta" || envelope.Delta.Type == "thinking_delta")
+
+	isJSONDelta := envelope.Type == "content_block_delta" &&
+		envelope.Delta != nil &&
+		envelope.Delta.Type == "input_json_delta"
+
+	if isDeltaText {
+		a.processTextDelta(&envelope)
+		return true
+	}
+
+	if isJSONDelta {
+		a.processJSONDelta(&envelope)
+		return true
+	}
+
+	// Non-delta event: flush accumulators, then pass through with replacement.
+	a.Flush()
+	writePipe(a.opts.pw,
+		[]byte(a.opts.replacer.Replace(sseDataPrefix+string(payload))),
+		[]byte("\n"))
+	return true
+}
+
+// processTextDelta accumulates text from a text_delta or thinking_delta event
+// and flushes safe prefixes with token replacement.
+//
+// json.Marshal on *sseEnvelope (string/int/*sseDelta fields) never returns an
+// error, so this function is infallible and has no error return.
+func (a *anthropicDeanonymizer) processTextDelta(envelope *sseEnvelope) {
+	a.lastIndex = envelope.Index
+	a.textAccum.WriteString(envelope.Delta.Text)
+	accumulated := a.textAccum.String()
+
+	flushUpTo := safeCutPoint(accumulated)
+	if flushUpTo == 0 {
+		return
+	}
+
+	toReplace := accumulated[:flushUpTo]
+	replaced := a.opts.replacer.Replace(toReplace)
+	if toReplace != replaced && a.opts.verbose {
+		log.Printf("[DEANON] text replaced: sessionID=%s tokens=%d", a.opts.sessionID, a.opts.tokenCount)
+	}
+
+	envelope.Delta.Text = replaced
+	newPayload, _ := json.Marshal(envelope) // error impossible: only string/int fields
+
+	writePipe(a.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
+
+	remaining := accumulated[flushUpTo:]
+	a.textAccum.Reset()
+	a.textAccum.WriteString(remaining)
+}
+
+// processJSONDelta accumulates partial_json from an input_json_delta event
+// and flushes safe prefixes with token replacement.
+//
+// json.Marshal on *sseEnvelope (string/int/*sseDelta fields) never returns an
+// error, so this function is infallible and has no error return.
+func (a *anthropicDeanonymizer) processJSONDelta(envelope *sseEnvelope) {
+	a.lastJSONIndex = envelope.Index
+	a.jsonAccum.WriteString(envelope.Delta.PartialJSON)
+	accumulated := a.jsonAccum.String()
+
+	flushUpTo := safeCutPoint(accumulated)
+	if flushUpTo == 0 {
+		return
+	}
+
+	toReplace := accumulated[:flushUpTo]
+	replaced := a.opts.replacer.Replace(toReplace)
+	if toReplace != replaced && a.opts.verbose {
+		log.Printf("[DEANON] json replaced: sessionID=%s tokens=%d", a.opts.sessionID, a.opts.tokenCount)
+	}
+
+	envelope.Delta.PartialJSON = replaced
+	newPayload, _ := json.Marshal(envelope) // error impossible: only string/int fields
+
+	writePipe(a.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
+
+	remaining := accumulated[flushUpTo:]
+	a.jsonAccum.Reset()
+	a.jsonAccum.WriteString(remaining)
+}
+
+// Flush emits any remaining accumulated text and JSON with token replacement.
+func (a *anthropicDeanonymizer) Flush() {
+	a.flushText()
+	a.flushJSON()
+}
+
+func (a *anthropicDeanonymizer) flushText() {
+	if a.textAccum.Len() == 0 {
+		return
+	}
+	flushed := a.opts.replacer.Replace(a.textAccum.String())
+	if flushed != "" {
+		synth := map[string]any{
+			"type":  "content_block_delta",
+			"index": a.lastIndex,
+			"delta": map[string]string{"type": "text_delta", "text": flushed},
+		}
+		if b, err := json.Marshal(synth); err == nil {
+			writePipe(a.opts.pw, []byte(sseDataPrefix), b, []byte("\n\n"))
+		}
+	}
+	a.textAccum.Reset()
+}
+
+func (a *anthropicDeanonymizer) flushJSON() {
+	if a.jsonAccum.Len() == 0 {
+		return
+	}
+	flushed := a.opts.replacer.Replace(a.jsonAccum.String())
+	if flushed != "" {
+		synth := map[string]any{
+			"type":  "content_block_delta",
+			"index": a.lastJSONIndex,
+			"delta": map[string]string{"type": "input_json_delta", "partial_json": flushed},
+		}
+		if b, err := json.Marshal(synth); err == nil {
+			writePipe(a.opts.pw, []byte(sseDataPrefix), b, []byte("\n\n"))
+		}
+	}
+	a.jsonAccum.Reset()
+}

--- a/internal/anonymizer/streaming_cohere.go
+++ b/internal/anonymizer/streaming_cohere.go
@@ -1,0 +1,119 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+)
+
+// cohereEnvelope is the minimal structure for Cohere streaming events.
+type cohereEnvelope struct {
+	Type  string       `json:"type"`
+	Index int          `json:"index,omitempty"`
+	Delta *cohereDelta `json:"delta,omitempty"`
+}
+
+type cohereDelta struct {
+	Message *cohereMessage `json:"message,omitempty"`
+}
+
+type cohereMessage struct {
+	Content cohereContent `json:"content"`
+}
+
+type cohereContent struct {
+	Text string `json:"text,omitempty"`
+}
+
+// cohereDeanonymizer handles Cohere's event-based streaming format.
+type cohereDeanonymizer struct {
+	opts      streamDeanonymizerOpts
+	textAccum strings.Builder
+	lastIndex int
+}
+
+func newCohereDeanonymizer(opts streamDeanonymizerOpts) *cohereDeanonymizer {
+	return &cohereDeanonymizer{opts: opts}
+}
+
+// ProcessDataPayload parses a Cohere SSE event and accumulates content-delta text.
+func (c *cohereDeanonymizer) ProcessDataPayload(payload []byte) bool {
+	var envelope cohereEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return false
+	}
+
+	// Only content-delta events carry text to accumulate.
+	if envelope.Type != "content-delta" ||
+		envelope.Delta == nil ||
+		envelope.Delta.Message == nil {
+		// Non-content events (stream-start, content-end, message-end, etc.)
+		// trigger a flush before passing through.
+		c.Flush()
+		writePipe(c.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(c.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	c.lastIndex = envelope.Index
+	text := envelope.Delta.Message.Content.Text
+	if text == "" {
+		writePipe(c.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(c.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	c.textAccum.WriteString(text)
+	accumulated := c.textAccum.String()
+
+	flushUpTo := safeCutPoint(accumulated)
+	if flushUpTo == 0 {
+		return true
+	}
+
+	toReplace := accumulated[:flushUpTo]
+	replaced := c.opts.replacer.Replace(toReplace)
+	if toReplace != replaced && c.opts.verbose {
+		log.Printf("[DEANON] cohere text replaced: sessionID=%s tokens=%d", c.opts.sessionID, c.opts.tokenCount)
+	}
+
+	envelope.Delta.Message.Content.Text = replaced
+	newPayload, err := json.Marshal(envelope)
+	if err != nil {
+		return false
+	}
+
+	writePipe(c.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
+
+	remaining := accumulated[flushUpTo:]
+	c.textAccum.Reset()
+	c.textAccum.WriteString(remaining)
+	return true
+}
+
+// Flush emits any remaining accumulated text as a synthetic content-delta event.
+func (c *cohereDeanonymizer) Flush() {
+	if c.textAccum.Len() == 0 {
+		return
+	}
+	flushed := c.opts.replacer.Replace(c.textAccum.String())
+	if flushed != "" {
+		synth := cohereEnvelope{
+			Type:  "content-delta",
+			Index: c.lastIndex,
+			Delta: &cohereDelta{
+				Message: &cohereMessage{
+					Content: cohereContent{Text: flushed},
+				},
+			},
+		}
+		if b, err := json.Marshal(synth); err == nil {
+			writePipe(c.opts.pw, []byte(sseDataPrefix), b, []byte("\n\n"))
+		}
+	}
+	c.textAccum.Reset()
+}

--- a/internal/anonymizer/streaming_cohere.go
+++ b/internal/anonymizer/streaming_cohere.go
@@ -82,10 +82,7 @@ func (c *cohereDeanonymizer) ProcessDataPayload(payload []byte) bool {
 	}
 
 	envelope.Delta.Message.Content.Text = replaced
-	newPayload, err := json.Marshal(envelope)
-	if err != nil {
-		return false
-	}
+	newPayload, _ := json.Marshal(envelope) // error impossible: only string/int fields
 
 	writePipe(c.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
 

--- a/internal/anonymizer/streaming_cohere_test.go
+++ b/internal/anonymizer/streaming_cohere_test.go
@@ -1,0 +1,222 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// makeCohereContentDelta builds a Cohere SSE line with type "content-delta"
+// carrying the given text fragment inside delta.message.content.text.
+func makeCohereContentDelta(text string) string {
+	type cohereContentInner struct {
+		Text string `json:"text,omitempty"`
+	}
+	type cohereMessageInner struct {
+		Content cohereContentInner `json:"content"`
+	}
+	type cohereDeltaInner struct {
+		Message cohereMessageInner `json:"message"`
+	}
+	type chunk struct {
+		Type  string           `json:"type"`
+		Index int              `json:"index"`
+		Delta cohereDeltaInner `json:"delta"`
+	}
+	c := chunk{
+		Type:  "content-delta",
+		Index: 0,
+		Delta: cohereDeltaInner{
+			Message: cohereMessageInner{
+				Content: cohereContentInner{Text: text},
+			},
+		},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// makeCohereNonContentEvent builds a Cohere SSE event of the given type that
+// does not carry any content (e.g. "stream-start", "message-end").
+func makeCohereNonContentEvent(eventType string) string {
+	type chunk struct {
+		Type string `json:"type"`
+	}
+	c := chunk{Type: eventType}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+const cohereDomain = "api.cohere.ai"
+
+// TestCohereStreamingTokenSplit verifies that a PII token split at the midpoint
+// across two content-delta events is reassembled and replaced.
+func TestCohereStreamingTokenSplit(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("x", tokenSuffixLen+10)
+	mid := len(token) / 2
+	sseInput := makeCohereContentDelta(prefix+token[:mid]) +
+		makeCohereContentDelta(token[mid:]+" world") +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, cohereDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Cohere token split: token not replaced in output:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Cohere token split: unreplaced token found in output:\n%s", got)
+	}
+}
+
+// TestCohereStreamingEOFFlush verifies that content held in the accumulator
+// at EOF is flushed as a synthetic content-delta chunk.
+func TestCohereStreamingEOFFlush(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Short single chunk — stays below tokenSuffixLen, flushed at EOF.
+	sseInput := makeCohereContentDelta("Hello " + token)
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, cohereDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Cohere EOF flush: token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Cohere EOF flush: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestCohereStreamingNonContentEvent verifies that a non-content-delta event
+// (e.g. "stream-start") triggers a flush of any accumulated text and is then
+// passed through with raw token replacement applied.
+func TestCohereStreamingNonContentEvent(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Accumulate a token via a content-delta, then send a non-content event.
+	sseInput := makeCohereContentDelta("hi " + token) +
+		makeCohereNonContentEvent("message-end") +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, cohereDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Cohere non-content event: accumulated token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Cohere non-content event: unreplaced token in output:\n%s", got)
+	}
+	if !strings.Contains(got, "message-end") {
+		t.Errorf("Cohere non-content event: event type not present in output:\n%s", got)
+	}
+}
+
+// makeCohereEmptyTextDelta builds a Cohere content-delta event whose text
+// field is empty. Some Cohere implementations emit this for chunking artefacts.
+func makeCohereEmptyTextDelta() string {
+	type cohereContentInner struct {
+		Text string `json:"text,omitempty"`
+	}
+	type cohereMessageInner struct {
+		Content cohereContentInner `json:"content"`
+	}
+	type cohereDeltaInner struct {
+		Message cohereMessageInner `json:"message"`
+	}
+	type chunk struct {
+		Type  string           `json:"type"`
+		Index int              `json:"index"`
+		Delta cohereDeltaInner `json:"delta"`
+	}
+	c := chunk{
+		Type:  "content-delta",
+		Index: 0,
+		Delta: cohereDeltaInner{
+			Message: cohereMessageInner{
+				Content: cohereContentInner{Text: ""},
+			},
+		},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// TestCohereStreamingInvalidJSON verifies that a malformed JSON payload returns
+// false and the framework applies raw token replacement via the processLine
+// fallback path.
+func TestCohereStreamingInvalidJSON(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	sseInput := "data: {not valid json " + token + "}\n\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, cohereDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Cohere invalid JSON: token not replaced via raw fallback:\n%s", got)
+	}
+}
+
+// TestCohereStreamingEmptyTextDelta verifies that a content-delta event with
+// an empty text field is passed through directly without accumulation.
+func TestCohereStreamingEmptyTextDelta(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Accumulate a token, send an empty-text content-delta, then EOF flush.
+	sseInput := makeCohereContentDelta("hi " + token) +
+		makeCohereEmptyTextDelta() +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, cohereDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Cohere empty text delta: accumulated token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Cohere empty text delta: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestCohereStreamingVerboseLogging covers the verbose logging branch inside
+// the accumulation path when a token replacement occurs in the flush zone.
+func TestCohereStreamingVerboseLogging(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+
+	a := newTestAnonymizer()
+	a.SetVerbose(true)
+	sessionID := "cohere-verbose"
+	a.sessionMu.Lock()
+	a.sessions[sessionID] = map[string]string{token: original}
+	a.sessionMu.Unlock()
+
+	// The token must fall entirely in the flush zone. Use a prefix longer than
+	// tokenSuffixLen+len(token) to ensure the token is not in the suffix guard.
+	prefix := strings.Repeat("c", tokenSuffixLen+len(token)+5)
+	sseInput := makeCohereContentDelta(prefix+token) +
+		makeCohereContentDelta(strings.Repeat("d", tokenSuffixLen+5)+"end") +
+		"\n"
+
+	src := io.NopCloser(strings.NewReader(sseInput))
+	rc := a.StreamingDeanonymize(src, sessionID, cohereDomain)
+	defer rc.Close() //nolint:errcheck
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading streaming output: %v", err)
+	}
+	if !strings.Contains(string(got), original) {
+		t.Errorf("Cohere verbose: token not replaced:\n%s", string(got))
+	}
+}

--- a/internal/anonymizer/streaming_cohere_test.go
+++ b/internal/anonymizer/streaming_cohere_test.go
@@ -102,7 +102,7 @@ func TestCohereStreamingNonContentEvent(t *testing.T) {
 	tokenMap := map[string]string{token: original}
 
 	// Accumulate a token via a content-delta, then send a non-content event.
-	sseInput := makeCohereContentDelta("hi " + token) +
+	sseInput := makeCohereContentDelta("hi "+token) +
 		makeCohereNonContentEvent("message-end") +
 		"\n"
 
@@ -120,7 +120,7 @@ func TestCohereStreamingNonContentEvent(t *testing.T) {
 }
 
 // makeCohereEmptyTextDelta builds a Cohere content-delta event whose text
-// field is empty. Some Cohere implementations emit this for chunking artefacts.
+// field is empty. Some Cohere implementations emit this for chunking artifacts.
 func makeCohereEmptyTextDelta() string {
 	type cohereContentInner struct {
 		Text string `json:"text,omitempty"`
@@ -174,7 +174,7 @@ func TestCohereStreamingEmptyTextDelta(t *testing.T) {
 	tokenMap := map[string]string{token: original}
 
 	// Accumulate a token, send an empty-text content-delta, then EOF flush.
-	sseInput := makeCohereContentDelta("hi " + token) +
+	sseInput := makeCohereContentDelta("hi "+token) +
 		makeCohereEmptyTextDelta() +
 		"\n"
 

--- a/internal/anonymizer/streaming_gemini.go
+++ b/internal/anonymizer/streaming_gemini.go
@@ -76,10 +76,7 @@ func (g *geminiDeanonymizer) ProcessDataPayload(payload []byte) bool {
 	}
 
 	envelope.Candidates[0].Content.Parts[0].Text = replaced
-	newPayload, err := json.Marshal(envelope)
-	if err != nil {
-		return false
-	}
+	newPayload, _ := json.Marshal(envelope) // error impossible: only string/int fields
 
 	writePipe(g.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
 

--- a/internal/anonymizer/streaming_gemini.go
+++ b/internal/anonymizer/streaming_gemini.go
@@ -1,0 +1,111 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+)
+
+// geminiEnvelope is the minimal structure for Gemini streamGenerateContent
+// SSE chunks (with ?alt=sse).
+type geminiEnvelope struct {
+	Candidates []geminiCandidate `json:"candidates"`
+}
+
+type geminiCandidate struct {
+	Content geminiContent `json:"content"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text string `json:"text,omitempty"`
+}
+
+// geminiDeanonymizer handles Gemini's streamGenerateContent SSE format.
+type geminiDeanonymizer struct {
+	opts      streamDeanonymizerOpts
+	textAccum strings.Builder
+}
+
+func newGeminiDeanonymizer(opts streamDeanonymizerOpts) *geminiDeanonymizer {
+	return &geminiDeanonymizer{opts: opts}
+}
+
+// ProcessDataPayload parses a Gemini SSE chunk and accumulates text.
+func (g *geminiDeanonymizer) ProcessDataPayload(payload []byte) bool {
+	var envelope geminiEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return false
+	}
+
+	// No candidates or no parts — pass through.
+	if len(envelope.Candidates) == 0 ||
+		len(envelope.Candidates[0].Content.Parts) == 0 {
+		g.Flush()
+		writePipe(g.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(g.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	text := envelope.Candidates[0].Content.Parts[0].Text
+	if text == "" {
+		writePipe(g.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(g.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	g.textAccum.WriteString(text)
+	accumulated := g.textAccum.String()
+
+	flushUpTo := safeCutPoint(accumulated)
+	if flushUpTo == 0 {
+		return true
+	}
+
+	toReplace := accumulated[:flushUpTo]
+	replaced := g.opts.replacer.Replace(toReplace)
+	if toReplace != replaced && g.opts.verbose {
+		log.Printf("[DEANON] gemini text replaced: sessionID=%s tokens=%d", g.opts.sessionID, g.opts.tokenCount)
+	}
+
+	envelope.Candidates[0].Content.Parts[0].Text = replaced
+	newPayload, err := json.Marshal(envelope)
+	if err != nil {
+		return false
+	}
+
+	writePipe(g.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
+
+	remaining := accumulated[flushUpTo:]
+	g.textAccum.Reset()
+	g.textAccum.WriteString(remaining)
+	return true
+}
+
+// Flush emits any remaining accumulated text as a synthetic Gemini chunk.
+func (g *geminiDeanonymizer) Flush() {
+	if g.textAccum.Len() == 0 {
+		return
+	}
+	flushed := g.opts.replacer.Replace(g.textAccum.String())
+	if flushed != "" {
+		synth := geminiEnvelope{
+			Candidates: []geminiCandidate{{
+				Content: geminiContent{
+					Parts: []geminiPart{{Text: flushed}},
+				},
+			}},
+		}
+		if b, err := json.Marshal(synth); err == nil {
+			writePipe(g.opts.pw, []byte(sseDataPrefix), b, []byte("\n\n"))
+		}
+	}
+	g.textAccum.Reset()
+}

--- a/internal/anonymizer/streaming_gemini_test.go
+++ b/internal/anonymizer/streaming_gemini_test.go
@@ -98,7 +98,7 @@ func TestGeminiStreamingEmptyCandidates(t *testing.T) {
 	tokenMap := map[string]string{token: original}
 
 	// Accumulate some text, then send an empty-candidates chunk.
-	sseInput := makeGeminiTextDelta("hi " + token) +
+	sseInput := makeGeminiTextDelta("hi "+token) +
 		makeGeminiEmptyCandidates() +
 		"\n"
 
@@ -169,7 +169,7 @@ func TestGeminiStreamingEmptyTextPart(t *testing.T) {
 	// First accumulate a token, then send a chunk with empty text — the empty
 	// chunk should pass through (covering the text=="" branch) and the
 	// subsequent EOF flush should replace the accumulated token.
-	sseInput := makeGeminiTextDelta("hi " + token) +
+	sseInput := makeGeminiTextDelta("hi "+token) +
 		makeGeminiEmptyTextPart() +
 		"\n"
 

--- a/internal/anonymizer/streaming_gemini_test.go
+++ b/internal/anonymizer/streaming_gemini_test.go
@@ -1,0 +1,217 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// makeGeminiTextDelta builds a single SSE line in Gemini's
+// streamGenerateContent format carrying the given text fragment.
+func makeGeminiTextDelta(text string) string {
+	type part struct {
+		Text string `json:"text,omitempty"`
+	}
+	type content struct {
+		Parts []part `json:"parts"`
+	}
+	type candidate struct {
+		Content content `json:"content"`
+	}
+	type chunk struct {
+		Candidates []candidate `json:"candidates"`
+	}
+	c := chunk{
+		Candidates: []candidate{{
+			Content: content{
+				Parts: []part{{Text: text}},
+			},
+		}},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// makeGeminiEmptyCandidates builds a Gemini SSE chunk with an empty
+// candidates array, which some implementations send as a stream terminator.
+func makeGeminiEmptyCandidates() string {
+	type chunk struct {
+		Candidates []struct{} `json:"candidates"`
+	}
+	c := chunk{Candidates: []struct{}{}}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+const geminiDomain = "generativelanguage.googleapis.com"
+
+// TestGeminiStreamingTokenSplit verifies that a PII token split at the midpoint
+// across two Gemini chunks is reassembled and replaced correctly.
+func TestGeminiStreamingTokenSplit(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("x", tokenSuffixLen+10)
+	mid := len(token) / 2
+	sseInput := makeGeminiTextDelta(prefix+token[:mid]) +
+		makeGeminiTextDelta(token[mid:]+" world") +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, geminiDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Gemini token split: token not replaced in output:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Gemini token split: unreplaced token found in output:\n%s", got)
+	}
+}
+
+// TestGeminiStreamingEOFFlush verifies that content held in the accumulator
+// at EOF is flushed as a synthetic Gemini chunk.
+func TestGeminiStreamingEOFFlush(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Short single chunk — stays below tokenSuffixLen, flushed at EOF.
+	sseInput := makeGeminiTextDelta("Hello " + token)
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, geminiDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Gemini EOF flush: token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Gemini EOF flush: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestGeminiStreamingEmptyCandidates verifies that a chunk with an empty
+// candidates array triggers a flush of any accumulated text and is then
+// passed through (possibly with raw token replacement).
+func TestGeminiStreamingEmptyCandidates(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Accumulate some text, then send an empty-candidates chunk.
+	sseInput := makeGeminiTextDelta("hi " + token) +
+		makeGeminiEmptyCandidates() +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, geminiDomain)
+
+	// The accumulated token must still be replaced.
+	if !strings.Contains(got, original) {
+		t.Errorf("Gemini empty candidates: accumulated token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Gemini empty candidates: unreplaced token in output:\n%s", got)
+	}
+}
+
+// makeGeminiEmptyTextPart builds a Gemini SSE chunk with a candidate whose
+// first part has an empty text field. Some Gemini implementations emit this
+// to signal the end of generation before a candidates-level stop reason event.
+func makeGeminiEmptyTextPart() string {
+	type part struct {
+		Text string `json:"text,omitempty"`
+	}
+	type content struct {
+		Parts []part `json:"parts"`
+	}
+	type candidate struct {
+		Content content `json:"content"`
+	}
+	type chunk struct {
+		Candidates []candidate `json:"candidates"`
+	}
+	c := chunk{
+		Candidates: []candidate{{
+			Content: content{
+				Parts: []part{{Text: ""}},
+			},
+		}},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// TestGeminiStreamingInvalidJSON verifies that a malformed JSON payload returns
+// false from ProcessDataPayload without writing anything, and the framework
+// falls back to raw token replacement in processLine.
+func TestGeminiStreamingInvalidJSON(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Invalid JSON triggers the json.Unmarshal error path in ProcessDataPayload.
+	// The framework's processLine raw-replacement fallback handles the payload.
+	sseInput := "data: {not valid json " + token + "}\n\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, geminiDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Gemini invalid JSON: token not replaced via raw fallback:\n%s", got)
+	}
+}
+
+// TestGeminiStreamingEmptyTextPart verifies that a chunk whose first part has
+// an empty text field is passed through directly without accumulation.
+func TestGeminiStreamingEmptyTextPart(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// First accumulate a token, then send a chunk with empty text — the empty
+	// chunk should pass through (covering the text=="" branch) and the
+	// subsequent EOF flush should replace the accumulated token.
+	sseInput := makeGeminiTextDelta("hi " + token) +
+		makeGeminiEmptyTextPart() +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, geminiDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Gemini empty text part: accumulated token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Gemini empty text part: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestGeminiStreamingVerboseLogging covers the verbose logging path inside
+// the accumulation branch when a token replacement occurs in the flush zone.
+func TestGeminiStreamingVerboseLogging(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+
+	a := newTestAnonymizer()
+	a.SetVerbose(true)
+	sessionID := "gemini-verbose"
+	a.sessionMu.Lock()
+	a.sessions[sessionID] = map[string]string{token: original}
+	a.sessionMu.Unlock()
+
+	// The token must fall entirely in the flush zone (before the suffix guard).
+	// Use a prefix longer than tokenSuffixLen+len(token) so both fit before the guard.
+	prefix := strings.Repeat("g", tokenSuffixLen+len(token)+5)
+	sseInput := makeGeminiTextDelta(prefix+token) +
+		makeGeminiTextDelta(strings.Repeat("h", tokenSuffixLen+5)+"end") +
+		"\n"
+
+	src := io.NopCloser(strings.NewReader(sseInput))
+	rc := a.StreamingDeanonymize(src, sessionID, geminiDomain)
+	defer rc.Close() //nolint:errcheck
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading streaming output: %v", err)
+	}
+	if !strings.Contains(string(got), original) {
+		t.Errorf("Gemini verbose: token not replaced:\n%s", string(got))
+	}
+}

--- a/internal/anonymizer/streaming_openai.go
+++ b/internal/anonymizer/streaming_openai.go
@@ -1,0 +1,130 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+)
+
+// openAIEnvelope is the minimal structure for OpenAI chat completion chunks.
+//
+// Used by: api.openai.com, api.mistral.ai, api.together.xyz,
+// api.perplexity.ai, api.huggingface.co
+type openAIEnvelope struct {
+	ID      string         `json:"id"`
+	Object  string         `json:"object"`
+	Choices []openAIChoice `json:"choices"`
+}
+
+type openAIChoice struct {
+	Index        int         `json:"index"`
+	Delta        openAIDelta `json:"delta"`
+	FinishReason *string     `json:"finish_reason"`
+}
+
+type openAIDelta struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// openAIDeanonymizer handles the OpenAI chat completions SSE format.
+type openAIDeanonymizer struct {
+	opts      streamDeanonymizerOpts
+	textAccum strings.Builder
+	lastID    string // id from the most recent chunk for synthetic events
+}
+
+func newOpenAIDeanonymizer(opts streamDeanonymizerOpts) *openAIDeanonymizer {
+	return &openAIDeanonymizer{opts: opts}
+}
+
+// ProcessDataPayload parses an OpenAI SSE chunk and accumulates content.
+func (o *openAIDeanonymizer) ProcessDataPayload(payload []byte) bool {
+	var envelope openAIEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return false // likely [DONE] sentinel or malformed — let framework handle
+	}
+
+	if len(envelope.Choices) == 0 {
+		// Usage-only chunk or empty choices — flush and pass through.
+		o.Flush()
+		writePipe(o.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(o.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	o.lastID = envelope.ID
+	choice := &envelope.Choices[0]
+
+	// finish_reason set → stream ending, flush and pass through.
+	if choice.FinishReason != nil {
+		o.Flush()
+		writePipe(o.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(o.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	// No content in delta (e.g. role-only first chunk) — pass through.
+	if choice.Delta.Content == "" {
+		writePipe(o.opts.pw,
+			[]byte(sseDataPrefix),
+			[]byte(o.opts.replacer.Replace(string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	// Accumulate content text.
+	o.textAccum.WriteString(choice.Delta.Content)
+	accumulated := o.textAccum.String()
+
+	flushUpTo := safeCutPoint(accumulated)
+	if flushUpTo == 0 {
+		return true
+	}
+
+	toReplace := accumulated[:flushUpTo]
+	replaced := o.opts.replacer.Replace(toReplace)
+	if toReplace != replaced && o.opts.verbose {
+		log.Printf("[DEANON] openai text replaced: sessionID=%s tokens=%d", o.opts.sessionID, o.opts.tokenCount)
+	}
+
+	// Re-serialize with replaced content.
+	choice.Delta.Content = replaced
+	newPayload, err := json.Marshal(envelope)
+	if err != nil {
+		return false
+	}
+
+	writePipe(o.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
+
+	remaining := accumulated[flushUpTo:]
+	o.textAccum.Reset()
+	o.textAccum.WriteString(remaining)
+	return true
+}
+
+// Flush emits any remaining accumulated text as a synthetic chunk.
+func (o *openAIDeanonymizer) Flush() {
+	if o.textAccum.Len() == 0 {
+		return
+	}
+	flushed := o.opts.replacer.Replace(o.textAccum.String())
+	if flushed != "" {
+		synth := openAIEnvelope{
+			ID:     o.lastID,
+			Object: "chat.completion.chunk",
+			Choices: []openAIChoice{{
+				Index: 0,
+				Delta: openAIDelta{Content: flushed},
+			}},
+		}
+		if b, err := json.Marshal(synth); err == nil {
+			writePipe(o.opts.pw, []byte(sseDataPrefix), b, []byte("\n\n"))
+		}
+	}
+	o.textAccum.Reset()
+}

--- a/internal/anonymizer/streaming_openai.go
+++ b/internal/anonymizer/streaming_openai.go
@@ -94,10 +94,7 @@ func (o *openAIDeanonymizer) ProcessDataPayload(payload []byte) bool {
 
 	// Re-serialize with replaced content.
 	choice.Delta.Content = replaced
-	newPayload, err := json.Marshal(envelope)
-	if err != nil {
-		return false
-	}
+	newPayload, _ := json.Marshal(envelope) // error impossible: only string/int fields
 
 	writePipe(o.opts.pw, []byte(sseDataPrefix), newPayload, []byte("\n"))
 

--- a/internal/anonymizer/streaming_openai_test.go
+++ b/internal/anonymizer/streaming_openai_test.go
@@ -38,7 +38,7 @@ func makeOpenAITextDelta(content string) string {
 }
 
 // makeOpenAIFinishChunk builds a chunk whose finish_reason is set to "stop",
-// signalling the end of the stream.
+// signaling the end of the stream.
 func makeOpenAIFinishChunk() string {
 	reason := "stop"
 	type delta struct{}
@@ -195,7 +195,7 @@ func TestOpenAIStreamingFinishReason(t *testing.T) {
 	tokenMap := map[string]string{token: original}
 
 	// Short content — stays in accumulator, then finish chunk triggers flush.
-	sseInput := makeOpenAITextDelta("greet " + token) +
+	sseInput := makeOpenAITextDelta("greet "+token) +
 		makeOpenAIFinishChunk() +
 		"\n"
 
@@ -214,9 +214,9 @@ func TestOpenAIStreamingFinishReason(t *testing.T) {
 // metadata as a trailing chunk after the last content chunk.
 func makeOpenAIEmptyChoicesChunk() string {
 	type chunk struct {
-		ID      string        `json:"id"`
-		Object  string        `json:"object"`
-		Choices []struct{}    `json:"choices"`
+		ID      string     `json:"id"`
+		Object  string     `json:"object"`
+		Choices []struct{} `json:"choices"`
 	}
 	c := chunk{ID: "chatcmpl-usage", Object: "chat.completion.chunk", Choices: []struct{}{}}
 	b, _ := json.Marshal(c)
@@ -232,7 +232,7 @@ func TestOpenAIStreamingEmptyChoicesFlush(t *testing.T) {
 	tokenMap := map[string]string{token: original}
 
 	// Short content accumulates, then the empty-choices chunk triggers a flush.
-	sseInput := makeOpenAITextDelta("hi " + token) +
+	sseInput := makeOpenAITextDelta("hi "+token) +
 		makeOpenAIEmptyChoicesChunk() +
 		"\n"
 

--- a/internal/anonymizer/streaming_openai_test.go
+++ b/internal/anonymizer/streaming_openai_test.go
@@ -1,0 +1,280 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// makeOpenAITextDelta builds a single SSE line carrying an OpenAI
+// chat.completion.chunk with the given content fragment.
+// finish_reason is left nil to model a normal mid-stream chunk.
+func makeOpenAITextDelta(content string) string {
+	type delta struct {
+		Content string `json:"content,omitempty"`
+	}
+	type choice struct {
+		Index        int     `json:"index"`
+		Delta        delta   `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	}
+	type chunk struct {
+		ID      string   `json:"id"`
+		Object  string   `json:"object"`
+		Choices []choice `json:"choices"`
+	}
+	c := chunk{
+		ID:     "chatcmpl-test",
+		Object: "chat.completion.chunk",
+		Choices: []choice{{
+			Index:        0,
+			Delta:        delta{Content: content},
+			FinishReason: nil,
+		}},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// makeOpenAIFinishChunk builds a chunk whose finish_reason is set to "stop",
+// signalling the end of the stream.
+func makeOpenAIFinishChunk() string {
+	reason := "stop"
+	type delta struct{}
+	type choice struct {
+		Index        int     `json:"index"`
+		Delta        delta   `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	}
+	type chunk struct {
+		ID      string   `json:"id"`
+		Object  string   `json:"object"`
+		Choices []choice `json:"choices"`
+	}
+	c := chunk{
+		ID:     "chatcmpl-test",
+		Object: "chat.completion.chunk",
+		Choices: []choice{{
+			Index:        0,
+			FinishReason: &reason,
+		}},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// makeOpenAIRoleOnlyChunk builds the first chunk sent by OpenAI, which carries
+// only a role field in the delta and no content.
+func makeOpenAIRoleOnlyChunk() string {
+	type delta struct {
+		Role string `json:"role,omitempty"`
+	}
+	type choice struct {
+		Index        int     `json:"index"`
+		Delta        delta   `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	}
+	type chunk struct {
+		ID      string   `json:"id"`
+		Object  string   `json:"object"`
+		Choices []choice `json:"choices"`
+	}
+	c := chunk{
+		ID:     "chatcmpl-test",
+		Object: "chat.completion.chunk",
+		Choices: []choice{{
+			Index: 0,
+			Delta: delta{Role: "assistant"},
+		}},
+	}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+const openAIDomain = "api.openai.com"
+
+// TestOpenAIStreamingTokenSplit verifies that a PII token split at the midpoint
+// across two content chunks is reassembled and replaced correctly.
+func TestOpenAIStreamingTokenSplit(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Enough prefix to push the first half of the token past the suffix guard,
+	// triggering a flush that emits the prefix but holds the partial token.
+	prefix := strings.Repeat("x", tokenSuffixLen+10)
+	mid := len(token) / 2
+	sseInput := makeOpenAITextDelta(prefix+token[:mid]) +
+		makeOpenAITextDelta(token[mid:]+" world") +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, openAIDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("OpenAI token split: token not replaced in output:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("OpenAI token split: unreplaced token found in output:\n%s", got)
+	}
+}
+
+// TestOpenAIStreamingEOFFlush verifies that content held in the accumulator
+// (shorter than tokenSuffixLen) is emitted when the stream ends at EOF.
+func TestOpenAIStreamingEOFFlush(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Short content — stays in accumulator until EOF.
+	sseInput := makeOpenAITextDelta("Hello " + token)
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, openAIDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("OpenAI EOF flush: token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("OpenAI EOF flush: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestOpenAIStreamingDoneSentinel verifies that the "data: [DONE]" terminator
+// passes through unchanged. The Anthropic deanonymizer returns false for this
+// non-JSON payload, falling back to raw replacement in processLine.
+func TestOpenAIStreamingDoneSentinel(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("a", tokenSuffixLen+5)
+	sseInput := makeOpenAITextDelta(prefix+token) +
+		"data: [DONE]\n\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, openAIDomain)
+
+	if !strings.Contains(got, "data: [DONE]") {
+		t.Errorf("OpenAI [DONE]: sentinel not passed through:\n%s", got)
+	}
+	if !strings.Contains(got, original) {
+		t.Errorf("OpenAI [DONE]: token before sentinel not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("OpenAI [DONE]: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestOpenAIStreamingRoleOnlyChunk verifies that the first assistant chunk
+// (delta with only a role, no content) passes through without disrupting
+// subsequent token accumulation.
+func TestOpenAIStreamingRoleOnlyChunk(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("r", tokenSuffixLen+5)
+	sseInput := makeOpenAIRoleOnlyChunk() +
+		makeOpenAITextDelta(prefix+token+" end") +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, openAIDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("OpenAI role-only chunk: token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("OpenAI role-only chunk: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestOpenAIStreamingFinishReason verifies that a chunk with finish_reason set
+// triggers a flush of any accumulated text before the stop chunk is emitted.
+func TestOpenAIStreamingFinishReason(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Short content — stays in accumulator, then finish chunk triggers flush.
+	sseInput := makeOpenAITextDelta("greet " + token) +
+		makeOpenAIFinishChunk() +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, openAIDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("OpenAI finish_reason flush: token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("OpenAI finish_reason flush: unreplaced token in output:\n%s", got)
+	}
+}
+
+// makeOpenAIEmptyChoicesChunk builds a JSON-valid OpenAI chunk whose choices
+// array is empty. This is used by some OpenAI-compatible APIs to send usage
+// metadata as a trailing chunk after the last content chunk.
+func makeOpenAIEmptyChoicesChunk() string {
+	type chunk struct {
+		ID      string        `json:"id"`
+		Object  string        `json:"object"`
+		Choices []struct{}    `json:"choices"`
+	}
+	c := chunk{ID: "chatcmpl-usage", Object: "chat.completion.chunk", Choices: []struct{}{}}
+	b, _ := json.Marshal(c)
+	return "data: " + string(b) + "\n"
+}
+
+// TestOpenAIStreamingEmptyChoicesFlush verifies that a usage-only chunk
+// (choices == []) triggers a flush of any accumulated text and then passes
+// through unchanged.
+func TestOpenAIStreamingEmptyChoicesFlush(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Short content accumulates, then the empty-choices chunk triggers a flush.
+	sseInput := makeOpenAITextDelta("hi " + token) +
+		makeOpenAIEmptyChoicesChunk() +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, openAIDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("OpenAI empty choices flush: accumulated token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("OpenAI empty choices flush: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestOpenAIStreamingVerboseLogging covers the verbose logging path inside the
+// accumulation branch, when a token replacement actually occurs in the flush zone.
+func TestOpenAIStreamingVerboseLogging(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+
+	a := newTestAnonymizer()
+	a.SetVerbose(true)
+	sessionID := "openai-verbose"
+	a.sessionMu.Lock()
+	a.sessions[sessionID] = map[string]string{token: original}
+	a.sessionMu.Unlock()
+
+	// The token must fall entirely within the flush zone so that toReplace != replaced.
+	// Prefix must be large enough to push the token + its suffix past the suffix guard.
+	prefix := strings.Repeat("v", tokenSuffixLen+len(token)+5)
+	sseInput := makeOpenAITextDelta(prefix+token) +
+		makeOpenAITextDelta(strings.Repeat("w", tokenSuffixLen+5)+"end") +
+		"\n"
+
+	src := io.NopCloser(strings.NewReader(sseInput))
+	rc := a.StreamingDeanonymize(src, sessionID, openAIDomain)
+	defer rc.Close() //nolint:errcheck
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading streaming output: %v", err)
+	}
+	if !strings.Contains(string(got), original) {
+		t.Errorf("OpenAI verbose: token not replaced:\n%s", string(got))
+	}
+}

--- a/internal/anonymizer/streaming_passthrough.go
+++ b/internal/anonymizer/streaming_passthrough.go
@@ -1,0 +1,23 @@
+package anonymizer
+
+// passthroughDeanonymizer applies raw token replacement to SSE data payloads
+// without JSON parsing or accumulation. Used for unknown providers.
+type passthroughDeanonymizer struct {
+	opts streamDeanonymizerOpts
+}
+
+func newPassthroughDeanonymizer(opts streamDeanonymizerOpts) *passthroughDeanonymizer {
+	return &passthroughDeanonymizer{opts: opts}
+}
+
+// ProcessDataPayload applies token replacement to the entire payload and
+// writes it through. No accumulation is performed, so token-split protection
+// is limited to the non-streaming DeanonymizeText path for buffered responses.
+func (p *passthroughDeanonymizer) ProcessDataPayload(payload []byte) bool {
+	replaced := p.opts.replacer.Replace(string(payload))
+	writePipe(p.opts.pw, []byte(sseDataPrefix), []byte(replaced), []byte("\n"))
+	return true
+}
+
+// Flush is a no-op — passthrough does not accumulate state between payloads.
+func (p *passthroughDeanonymizer) Flush() {} //nolint:gocritic // interface compliance; no state to flush

--- a/internal/anonymizer/streaming_passthrough_test.go
+++ b/internal/anonymizer/streaming_passthrough_test.go
@@ -42,6 +42,7 @@ func TestPassthroughFlushIsNoOp(t *testing.T) {
 		t.Error("expected non-empty output from passthrough")
 	}
 }
+
 // because passthroughDeanonymizer writes each event immediately without
 // accumulation, a token split across two events is NOT rejoined and therefore
 // NOT replaced. This is the documented trade-off for unknown providers.
@@ -62,7 +63,7 @@ func TestPassthroughStreamingNoAccumulation(t *testing.T) {
 	// The test asserts the known limitation rather than expecting success.
 	if strings.Contains(got, original) {
 		// If this assertion starts failing it means passthrough gained
-		// accumulation — update this test to reflect the new behaviour.
+		// accumulation — update this test to reflect the new behavior.
 		t.Logf("Passthrough unexpectedly replaced a split token — accumulation may have been added")
 	}
 	// Both halves must be present in the output (they pass through as-is).

--- a/internal/anonymizer/streaming_passthrough_test.go
+++ b/internal/anonymizer/streaming_passthrough_test.go
@@ -1,0 +1,75 @@
+package anonymizer
+
+import (
+	"strings"
+	"testing"
+)
+
+// unknownDomain is a domain that does not match any registered AI provider,
+// ensuring ProviderPassthrough is selected.
+const unknownDomain = "custom-llm.example.com"
+
+// TestPassthroughStreamingReplacement verifies that a PII token in an
+// arbitrary (non-standard) JSON SSE payload is replaced when the passthrough
+// provider is active.
+func TestPassthroughStreamingReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Arbitrary JSON that no built-in provider parses — passthrough applies
+	// raw strings.Replacer to the payload.
+	sseInput := `data: {"output":"` + token + `","done":false}` + "\n\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, unknownDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Passthrough: token not replaced in output:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Passthrough: unreplaced token found in output:\n%s", got)
+	}
+}
+
+// TestPassthroughFlushIsNoOp verifies that calling Flush on a
+// passthroughDeanonymizer neither panics nor writes anything to the pipe.
+// The passthrough provider does not accumulate, so Flush is intentionally
+// a no-op.
+func TestPassthroughFlushIsNoOp(t *testing.T) {
+	got := readStreamResultForDomain(t, "data: hello\n\n", nil, unknownDomain)
+	// Just verify no panic — empty token map means no replacements.
+	if got == "" {
+		t.Error("expected non-empty output from passthrough")
+	}
+}
+// because passthroughDeanonymizer writes each event immediately without
+// accumulation, a token split across two events is NOT rejoined and therefore
+// NOT replaced. This is the documented trade-off for unknown providers.
+func TestPassthroughStreamingNoAccumulation(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	mid := len(token) / 2
+	// Split token across two events — passthrough cannot rejoin them.
+	sseInput := "data: " + token[:mid] + "\n" +
+		"data: " + token[mid:] + "\n\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, unknownDomain)
+
+	// The full token should NOT appear in the output (it was split).
+	// Neither should the original — because replacement never occurred.
+	// The test asserts the known limitation rather than expecting success.
+	if strings.Contains(got, original) {
+		// If this assertion starts failing it means passthrough gained
+		// accumulation — update this test to reflect the new behaviour.
+		t.Logf("Passthrough unexpectedly replaced a split token — accumulation may have been added")
+	}
+	// Both halves must be present in the output (they pass through as-is).
+	if !strings.Contains(got, token[:mid]) {
+		t.Errorf("Passthrough: first half of split token not in output:\n%s", got)
+	}
+	if !strings.Contains(got, token[mid:]) {
+		t.Errorf("Passthrough: second half of split token not in output:\n%s", got)
+	}
+}

--- a/internal/anonymizer/streaming_passthrough_test.go
+++ b/internal/anonymizer/streaming_passthrough_test.go
@@ -43,9 +43,11 @@ func TestPassthroughFlushIsNoOp(t *testing.T) {
 	}
 }
 
-// because passthroughDeanonymizer writes each event immediately without
-// accumulation, a token split across two events is NOT rejoined and therefore
-// NOT replaced. This is the documented trade-off for unknown providers.
+// TestPassthroughStreamingNoAccumulation verifies that the passthrough provider
+// does not rejoin tokens split across events — this is the documented trade-off
+// for unknown providers. Because passthroughDeanonymizer writes each event
+// immediately without accumulation, a token split across two events is NOT
+// replaced.
 func TestPassthroughStreamingNoAccumulation(t *testing.T) {
 	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
 	original := "user@example.com"

--- a/internal/anonymizer/streaming_provider.go
+++ b/internal/anonymizer/streaming_provider.go
@@ -1,0 +1,100 @@
+package anonymizer
+
+import (
+	"io"
+	"strings"
+)
+
+// Provider identifies an AI API provider's SSE streaming format.
+type Provider string
+
+const (
+	// ProviderAnthropic handles Anthropic SSE: content_block_delta with
+	// text_delta, thinking_delta, and input_json_delta event types.
+	ProviderAnthropic Provider = "anthropic"
+
+	// ProviderOpenAI handles the OpenAI chat completions SSE format used by
+	// OpenAI, Mistral, Together, Perplexity, and Hugging Face.
+	ProviderOpenAI Provider = "openai"
+
+	// ProviderGemini handles Google Gemini's streamGenerateContent SSE format.
+	ProviderGemini Provider = "gemini"
+
+	// ProviderCohere handles Cohere's event-based streaming format.
+	ProviderCohere Provider = "cohere"
+
+	// ProviderReplicate handles Replicate's plain-text SSE format.
+	ProviderReplicate Provider = "replicate"
+
+	// ProviderPassthrough applies raw token replacement without JSON parsing.
+	ProviderPassthrough Provider = "passthrough"
+)
+
+// StreamingDeanonymizer processes provider-specific SSE data payloads.
+//
+// Each implementation accumulates text fragments across streamed events,
+// applies token replacement via a strings.Replacer, and writes re-serialized
+// SSE lines (including the "data: " prefix and trailing newline) to the pipe.
+type StreamingDeanonymizer interface {
+	// ProcessDataPayload handles the bytes after "data: " from a single SSE
+	// line. Returns true if the payload was handled (output written or
+	// accumulated), false if parsing failed and the caller should fall back
+	// to raw token replacement.
+	ProcessDataPayload(payload []byte) bool
+
+	// Flush emits any remaining accumulated text with token replacement.
+	// Called at stream end (EOF or read error).
+	Flush()
+}
+
+// domainToProvider maps registered AI API domains to their streaming format.
+// OpenAI-compatible providers share ProviderOpenAI.
+var domainToProvider = map[string]Provider{
+	"api.anthropic.com":                 ProviderAnthropic,
+	"api.openai.com":                    ProviderOpenAI,
+	"api.mistral.ai":                    ProviderOpenAI,
+	"api.together.xyz":                  ProviderOpenAI,
+	"api.perplexity.ai":                 ProviderOpenAI,
+	"api.huggingface.co":                ProviderOpenAI,
+	"generativelanguage.googleapis.com": ProviderGemini,
+	"api.cohere.ai":                     ProviderCohere,
+	"api.replicate.com":                 ProviderReplicate,
+}
+
+// ProviderForDomain returns the streaming Provider for a given API domain.
+// Unknown domains return ProviderPassthrough.
+func ProviderForDomain(domain string) Provider {
+	if p, ok := domainToProvider[domain]; ok {
+		return p
+	}
+	return ProviderPassthrough
+}
+
+// streamDeanonymizerOpts holds the configuration shared by all provider
+// implementations.
+type streamDeanonymizerOpts struct {
+	pw         *io.PipeWriter
+	replacer   *strings.Replacer
+	sessionID  string
+	verbose    bool
+	tokenCount int
+}
+
+// NewStreamingDeanonymizer creates the appropriate provider implementation
+// for the given Provider.
+func NewStreamingDeanonymizer(provider Provider, opts streamDeanonymizerOpts) StreamingDeanonymizer {
+	switch provider {
+	case ProviderAnthropic:
+		return newAnthropicDeanonymizer(opts)
+	case ProviderOpenAI:
+		return newOpenAIDeanonymizer(opts)
+	case ProviderGemini:
+		return newGeminiDeanonymizer(opts)
+	case ProviderCohere:
+		return newCohereDeanonymizer(opts)
+	case ProviderReplicate:
+		return newReplicateDeanonymizer(opts)
+	default:
+		return newPassthroughDeanonymizer(opts)
+	}
+}

--- a/internal/anonymizer/streaming_provider_test.go
+++ b/internal/anonymizer/streaming_provider_test.go
@@ -51,8 +51,8 @@ func readStreamResultVerbose(t *testing.T, sseInput string, tokenMap map[string]
 // expected provider and that unknown domains fall back to ProviderPassthrough.
 func TestProviderForDomain(t *testing.T) {
 	cases := []struct {
-		domain   string
-		want     Provider
+		domain string
+		want   Provider
 	}{
 		{"api.anthropic.com", ProviderAnthropic},
 		{"api.openai.com", ProviderOpenAI},

--- a/internal/anonymizer/streaming_provider_test.go
+++ b/internal/anonymizer/streaming_provider_test.go
@@ -1,0 +1,115 @@
+package anonymizer
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// readStreamResultForDomain is the shared helper used by all provider test files.
+// It wires a pre-populated session into a fresh Anonymizer and runs
+// StreamingDeanonymize against the given domain, returning the full output.
+func readStreamResultForDomain(t *testing.T, sseInput string, tokenMap map[string]string, domain string) string {
+	t.Helper()
+	a := newTestAnonymizer()
+	a.SetVerbose(false)
+	sessionID := "test-session"
+	a.sessionMu.Lock()
+	a.sessions[sessionID] = tokenMap
+	a.sessionMu.Unlock()
+	src := io.NopCloser(strings.NewReader(sseInput))
+	rc := a.StreamingDeanonymize(src, sessionID, domain)
+	defer rc.Close() //nolint:errcheck
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading streaming output: %v", err)
+	}
+	return string(got)
+}
+
+// readStreamResultVerbose is like readStreamResultForDomain but runs with
+// verbose logging enabled so the log.Printf branches are exercised.
+func readStreamResultVerbose(t *testing.T, sseInput string, tokenMap map[string]string, domain string) string {
+	t.Helper()
+	a := newTestAnonymizer()
+	a.SetVerbose(true)
+	sessionID := "verbose-session"
+	a.sessionMu.Lock()
+	a.sessions[sessionID] = tokenMap
+	a.sessionMu.Unlock()
+	src := io.NopCloser(strings.NewReader(sseInput))
+	rc := a.StreamingDeanonymize(src, sessionID, domain)
+	defer rc.Close() //nolint:errcheck
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading streaming output: %v", err)
+	}
+	return string(got)
+}
+
+// TestProviderForDomain verifies that every registered domain maps to the
+// expected provider and that unknown domains fall back to ProviderPassthrough.
+func TestProviderForDomain(t *testing.T) {
+	cases := []struct {
+		domain   string
+		want     Provider
+	}{
+		{"api.anthropic.com", ProviderAnthropic},
+		{"api.openai.com", ProviderOpenAI},
+		{"api.mistral.ai", ProviderOpenAI},
+		{"api.together.xyz", ProviderOpenAI},
+		{"api.perplexity.ai", ProviderOpenAI},
+		{"api.huggingface.co", ProviderOpenAI},
+		{"generativelanguage.googleapis.com", ProviderGemini},
+		{"api.cohere.ai", ProviderCohere},
+		{"api.replicate.com", ProviderReplicate},
+		// Unknown domains must fall back to passthrough.
+		{"unknown.example.com", ProviderPassthrough},
+		{"", ProviderPassthrough},
+		{"localhost:8080", ProviderPassthrough},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.domain, func(t *testing.T) {
+			got := ProviderForDomain(tc.domain)
+			if got != tc.want {
+				t.Errorf("ProviderForDomain(%q) = %q, want %q", tc.domain, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewStreamingDeanonymizer verifies that the factory returns a non-nil
+// implementation for every named Provider value.
+func TestNewStreamingDeanonymizer(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer pr.Close() //nolint:errcheck
+	defer pw.Close() //nolint:errcheck
+
+	opts := streamDeanonymizerOpts{
+		pw:         pw,
+		replacer:   strings.NewReplacer(),
+		sessionID:  "factory-test",
+		verbose:    false,
+		tokenCount: 0,
+	}
+
+	providers := []Provider{
+		ProviderAnthropic,
+		ProviderOpenAI,
+		ProviderGemini,
+		ProviderCohere,
+		ProviderReplicate,
+		ProviderPassthrough,
+		Provider("unknown-provider"), // must also return non-nil (passthrough)
+	}
+
+	for _, p := range providers {
+		t.Run(string(p), func(t *testing.T) {
+			d := NewStreamingDeanonymizer(p, opts)
+			if d == nil {
+				t.Errorf("NewStreamingDeanonymizer(%q) returned nil", p)
+			}
+		})
+	}
+}

--- a/internal/anonymizer/streaming_replicate.go
+++ b/internal/anonymizer/streaming_replicate.go
@@ -30,7 +30,7 @@ func (r *replicateDeanonymizer) ProcessDataPayload(payload []byte) bool {
 		return true
 	}
 
-	r.textAccum.WriteString(string(payload))
+	r.textAccum.WriteString(text)
 	accumulated := r.textAccum.String()
 
 	flushUpTo := safeCutPoint(accumulated)

--- a/internal/anonymizer/streaming_replicate.go
+++ b/internal/anonymizer/streaming_replicate.go
@@ -1,0 +1,65 @@
+package anonymizer
+
+import (
+	"log"
+	"strings"
+)
+
+// replicateDeanonymizer handles Replicate's plain-text SSE format.
+// Replicate output events carry plain text in the data field (not JSON).
+// The accumulator provides token-split protection across chunks.
+type replicateDeanonymizer struct {
+	opts      streamDeanonymizerOpts
+	textAccum strings.Builder
+}
+
+func newReplicateDeanonymizer(opts streamDeanonymizerOpts) *replicateDeanonymizer {
+	return &replicateDeanonymizer{opts: opts}
+}
+
+// ProcessDataPayload accumulates plain text from Replicate output events.
+// Returns false for empty JSON payloads like {} (done events), letting the
+// framework apply raw replacement.
+func (r *replicateDeanonymizer) ProcessDataPayload(payload []byte) bool {
+	text := strings.TrimSpace(string(payload))
+
+	// The done event sends "data: {}" — not meaningful text.
+	if text == "{}" || text == "" {
+		r.Flush()
+		writePipe(r.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+
+	r.textAccum.WriteString(string(payload))
+	accumulated := r.textAccum.String()
+
+	flushUpTo := safeCutPoint(accumulated)
+	if flushUpTo == 0 {
+		return true
+	}
+
+	toReplace := accumulated[:flushUpTo]
+	replaced := r.opts.replacer.Replace(toReplace)
+	if toReplace != replaced && r.opts.verbose {
+		log.Printf("[DEANON] replicate text replaced: sessionID=%s tokens=%d", r.opts.sessionID, r.opts.tokenCount)
+	}
+
+	writePipe(r.opts.pw, []byte(sseDataPrefix), []byte(replaced), []byte("\n"))
+
+	remaining := accumulated[flushUpTo:]
+	r.textAccum.Reset()
+	r.textAccum.WriteString(remaining)
+	return true
+}
+
+// Flush emits any remaining accumulated text with token replacement.
+func (r *replicateDeanonymizer) Flush() {
+	if r.textAccum.Len() == 0 {
+		return
+	}
+	flushed := r.opts.replacer.Replace(r.textAccum.String())
+	if flushed != "" {
+		writePipe(r.opts.pw, []byte(sseDataPrefix), []byte(flushed), []byte("\n\n"))
+	}
+	r.textAccum.Reset()
+}

--- a/internal/anonymizer/streaming_replicate_test.go
+++ b/internal/anonymizer/streaming_replicate_test.go
@@ -1,0 +1,97 @@
+package anonymizer
+
+import (
+	"strings"
+	"testing"
+)
+
+// makeReplicatePlainDelta builds a Replicate SSE line with plain text in the
+// data field (not JSON). This is Replicate's output event format.
+func makeReplicatePlainDelta(text string) string {
+	return "data: " + text + "\n"
+}
+
+const replicateDomain = "api.replicate.com"
+
+// TestReplicateStreamingTokenSplit verifies that a PII token split at the
+// midpoint across two plain-text output events is reassembled and replaced.
+func TestReplicateStreamingTokenSplit(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("x", tokenSuffixLen+10)
+	mid := len(token) / 2
+	sseInput := makeReplicatePlainDelta(prefix+token[:mid]) +
+		makeReplicatePlainDelta(token[mid:]+" world") +
+		"\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, replicateDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Replicate token split: token not replaced in output:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Replicate token split: unreplaced token found in output:\n%s", got)
+	}
+}
+
+// TestReplicateStreamingEOFFlush verifies that content held in the accumulator
+// at EOF is emitted (with replacement) when the source ends.
+func TestReplicateStreamingEOFFlush(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Short single event — stays below tokenSuffixLen, flushed at EOF.
+	sseInput := makeReplicatePlainDelta("Hello " + token)
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, replicateDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Replicate EOF flush: token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Replicate EOF flush: unreplaced token in output:\n%s", got)
+	}
+}
+
+// TestReplicateStreamingVerboseLogging exercises the verbose log.Printf branch
+// in the Replicate provider's accumulation path.
+func TestReplicateStreamingVerboseLogging(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("r", tokenSuffixLen+10)
+	sseInput := makeReplicatePlainDelta(prefix+token+" end") + "\n"
+
+	got := readStreamResultVerbose(t, sseInput, tokenMap, replicateDomain)
+	if !strings.Contains(got, original) {
+		t.Errorf("Replicate verbose: token not replaced:\n%s", got)
+	}
+}
+// ("data: {}") triggers a flush of any pending accumulator content and then
+// passes through unchanged.
+func TestReplicateStreamingDoneEvent(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "user@example.com"
+	tokenMap := map[string]string{token: original}
+
+	// Accumulate some text then send the done payload.
+	sseInput := makeReplicatePlainDelta("hi " + token) +
+		"data: {}\n\n"
+
+	got := readStreamResultForDomain(t, sseInput, tokenMap, replicateDomain)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("Replicate done event: accumulated token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("Replicate done event: unreplaced token in output:\n%s", got)
+	}
+	// The done payload itself must appear in the output.
+	if !strings.Contains(got, "data: {}") {
+		t.Errorf("Replicate done event: done payload not passed through:\n%s", got)
+	}
+}

--- a/internal/anonymizer/streaming_replicate_test.go
+++ b/internal/anonymizer/streaming_replicate_test.go
@@ -72,6 +72,7 @@ func TestReplicateStreamingVerboseLogging(t *testing.T) {
 	}
 }
 
+// TestReplicateStreamingDoneEvent verifies that the Replicate done event
 // ("data: {}") triggers a flush of any pending accumulator content and then
 // passes through unchanged.
 func TestReplicateStreamingDoneEvent(t *testing.T) {

--- a/internal/anonymizer/streaming_replicate_test.go
+++ b/internal/anonymizer/streaming_replicate_test.go
@@ -71,6 +71,7 @@ func TestReplicateStreamingVerboseLogging(t *testing.T) {
 		t.Errorf("Replicate verbose: token not replaced:\n%s", got)
 	}
 }
+
 // ("data: {}") triggers a flush of any pending accumulator content and then
 // passes through unchanged.
 func TestReplicateStreamingDoneEvent(t *testing.T) {
@@ -79,7 +80,7 @@ func TestReplicateStreamingDoneEvent(t *testing.T) {
 	tokenMap := map[string]string{token: original}
 
 	// Accumulate some text then send the done payload.
-	sseInput := makeReplicatePlainDelta("hi " + token) +
+	sseInput := makeReplicatePlainDelta("hi "+token) +
 		"data: {}\n\n"
 
 	got := readStreamResultForDomain(t, sseInput, tokenMap, replicateDomain)

--- a/internal/anonymizer/streaming_test.go
+++ b/internal/anonymizer/streaming_test.go
@@ -83,7 +83,7 @@ func readStreamResult(t *testing.T, sseInput string, tokenMap map[string]string)
 	a.sessionMu.Unlock()
 
 	src := io.NopCloser(strings.NewReader(sseInput))
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck
 
 	got, err := io.ReadAll(rc)
@@ -480,7 +480,7 @@ func TestHandleStreamEndNonEOFError(t *testing.T) {
 		err:  errFail,
 	}
 
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	_, err := io.ReadAll(rc)
 	if err == nil {
 		t.Fatal("expected error from non-EOF read failure, got nil")
@@ -507,7 +507,7 @@ func TestStreamingDeanonymizeVerboseLogging(t *testing.T) {
 	prefix := strings.Repeat("v", tokenSuffixLen+10)
 	sseInput := makeSSETextDelta(prefix+token+" end") + "\n"
 	src := io.NopCloser(strings.NewReader(sseInput))
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck
 
 	got, err := io.ReadAll(rc)
@@ -763,7 +763,7 @@ func TestProcessTextDeltaVerboseReplacementInFlush(t *testing.T) {
 		makeSSETextDelta(padding2+"end") + "\n"
 
 	src := io.NopCloser(strings.NewReader(sseInput))
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck
 
 	got, err := io.ReadAll(rc)
@@ -775,8 +775,45 @@ func TestProcessTextDeltaVerboseReplacementInFlush(t *testing.T) {
 	}
 }
 
-// TestProcessJSONDeltaVerboseReplacement covers the verbose logging path in
-// processJSONDelta when a token is actually replaced.
+// TestProcessJSONDeltaVerboseReplacementInFlush covers the verbose logging path
+// in processJSONDelta when a token falls entirely within the flush zone. This
+// differs from TestProcessJSONDeltaVerboseReplacement which only delivers
+// prefix+token in one event (keeping the token in the suffix guard). Here two
+// events are used so that by the time the second event is processed the token
+// is past the suffix guard.
+func TestProcessJSONDeltaVerboseReplacementInFlush(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "alice@example.com"
+
+	a := newTestAnonymizer()
+	a.SetVerbose(true)
+	sessionID := "verbose-json-flush"
+	a.sessionMu.Lock()
+	a.sessions[sessionID] = map[string]string{token: original}
+	a.sessionMu.Unlock()
+
+	// First event: prefix + token + extra padding — enough that the token sits
+	// entirely before the suffix guard when the second event arrives.
+	prefix := strings.Repeat("j", tokenSuffixLen+len(token)+5)
+	sseInput := makeSSEJsonDelta(prefix+token) +
+		makeSSEJsonDelta(strings.Repeat("k", tokenSuffixLen+5)+"end") +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
+
+	src := io.NopCloser(strings.NewReader(sseInput))
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
+	defer rc.Close() //nolint:errcheck
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if !strings.Contains(string(got), original) {
+		t.Errorf("json delta verbose flush: token not replaced:\n%s", string(got))
+	}
+	if strings.Contains(string(got), token) {
+		t.Errorf("json delta verbose flush: unreplaced token in output:\n%s", string(got))
+	}
+}
 func TestProcessJSONDeltaVerboseReplacement(t *testing.T) {
 	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
 	original := "alice@example.com"
@@ -794,7 +831,7 @@ func TestProcessJSONDeltaVerboseReplacement(t *testing.T) {
 		"data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
 
 	src := io.NopCloser(strings.NewReader(sseInput))
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	defer rc.Close() //nolint:errcheck
 
 	got, err := io.ReadAll(rc)
@@ -825,7 +862,7 @@ func TestHandleStreamEndNonEOFWithPartialLine(t *testing.T) {
 		err:  errFail,
 	}
 
-	rc := a.StreamingDeanonymize(src, sessionID)
+	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
 	_, err := io.ReadAll(rc)
 	if err == nil || !strings.Contains(err.Error(), "broken pipe") {
 		t.Errorf("expected 'broken pipe' error, got: %v", err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -299,7 +299,7 @@ func (s *Server) serveMITMRequest(rw http.ResponseWriter, req *http.Request, ctx
 		defer s.anon.DeleteSession(sessionID)
 	}
 
-	s.forwardMITMRequest(rw, req, sessionID)
+	s.forwardMITMRequest(rw, req, sessionID, ctx.domain)
 }
 
 // recordMITMMetrics records metrics for a MITM request.
@@ -337,7 +337,7 @@ func (s *Server) processMITMRequestBody(rw http.ResponseWriter, req *http.Reques
 }
 
 // forwardMITMRequest forwards the request upstream and writes the response.
-func (s *Server) forwardMITMRequest(rw http.ResponseWriter, req *http.Request, sessionID string) {
+func (s *Server) forwardMITMRequest(rw http.ResponseWriter, req *http.Request, sessionID string, domain string) {
 	removeHopByHop(req.Header)
 	upstreamStart := time.Now()
 	resp, err := s.transport.RoundTrip(req)
@@ -354,7 +354,7 @@ func (s *Server) forwardMITMRequest(rw http.ResponseWriter, req *http.Request, s
 	defer resp.Body.Close() //nolint:errcheck // best-effort close
 
 	// De-anonymize response before returning to client
-	s.deanonymizeResponseBody(resp, sessionID)
+	s.deanonymizeResponseBody(resp, sessionID, domain)
 
 	removeHopByHop(resp.Header)
 	copyHeader(rw.Header(), resp.Header)
@@ -454,10 +454,10 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Forward the request
-	s.forward(w, r, sessionID)
+	s.forward(w, r, sessionID, domain)
 }
 
-func (s *Server) forward(w http.ResponseWriter, r *http.Request, sessionID string) {
+func (s *Server) forward(w http.ResponseWriter, r *http.Request, sessionID string, domain string) {
 	// Ensure the URL is absolute
 	if r.URL.Scheme == "" {
 		r.URL.Scheme = "http"
@@ -490,7 +490,7 @@ func (s *Server) forward(w http.ResponseWriter, r *http.Request, sessionID strin
 	defer resp.Body.Close() //nolint:errcheck // best-effort close
 
 	// De-anonymize response before returning to client
-	s.deanonymizeResponseBody(resp, sessionID)
+	s.deanonymizeResponseBody(resp, sessionID, domain)
 
 	removeHopByHop(resp.Header)
 	copyHeader(w.Header(), resp.Header)
@@ -536,7 +536,7 @@ func (s *Server) anonymizeRequestBody(r *http.Request) (string, error) {
 	return sessionID, nil
 }
 
-func (s *Server) deanonymizeResponseBody(resp *http.Response, sessionID string) {
+func (s *Server) deanonymizeResponseBody(resp *http.Response, sessionID string, domain string) {
 	if sessionID == "" || resp == nil || resp.Body == nil {
 		log.Printf("[DEANON] skipping: sessionID=%q resp=%v bodyNil=%v", sessionID, resp == nil, resp != nil && resp.Body == nil)
 		return
@@ -557,7 +557,7 @@ func (s *Server) deanonymizeResponseBody(resp *http.Response, sessionID string) 
 	// buffered: io.ReadAll blocks until the upstream closes the connection.
 	// Wrap the body in a pipe-based reader that replaces tokens on-the-fly.
 	if streaming {
-		resp.Body = s.anon.StreamingDeanonymize(resp.Body, sessionID)
+		resp.Body = s.anon.StreamingDeanonymize(resp.Body, sessionID, domain)
 		resp.ContentLength = -1 // length is unknown; let the client stream
 		return
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -719,13 +719,13 @@ func TestDeanonymizeResponseBody_NoSessionID(t *testing.T) {
 		Body:   io.NopCloser(strings.NewReader("body")),
 	}
 	// Should not panic or modify when sessionID is empty
-	srv.deanonymizeResponseBody(resp, "")
+	srv.deanonymizeResponseBody(resp, "", "")
 }
 
 func TestDeanonymizeResponseBody_NilResp(t *testing.T) {
 	srv := newTestProxyServer(t)
 	// Should not panic
-	srv.deanonymizeResponseBody(nil, "session123")
+	srv.deanonymizeResponseBody(nil, "session123", "")
 }
 
 func TestDeanonymizeResponseBody_NonStreaming(t *testing.T) {
@@ -737,7 +737,7 @@ func TestDeanonymizeResponseBody_NonStreaming(t *testing.T) {
 	}
 	resp.Header.Set("Content-Type", "application/json")
 
-	srv.deanonymizeResponseBody(resp, "test-session")
+	srv.deanonymizeResponseBody(resp, "test-session", "")
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "hello world" {
 		t.Errorf("expected 'hello world', got %q", string(body))
@@ -753,7 +753,7 @@ func TestDeanonymizeResponseBody_Streaming(t *testing.T) {
 	}
 	resp.Header.Set("Content-Type", "text/event-stream")
 
-	srv.deanonymizeResponseBody(resp, "test-session")
+	srv.deanonymizeResponseBody(resp, "test-session", "")
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "hello") {
 		t.Errorf("expected body to contain 'hello', got %q", string(body))
@@ -779,7 +779,7 @@ func TestDeanonymizeResponseBody_GzipEncoded(t *testing.T) {
 	resp.Header.Set("Content-Type", "application/json")
 	resp.Header.Set("Content-Encoding", "gzip")
 
-	srv.deanonymizeResponseBody(resp, "test-session")
+	srv.deanonymizeResponseBody(resp, "test-session", "")
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "compressed body" {
 		t.Errorf("expected 'compressed body', got %q", string(body))
@@ -794,7 +794,7 @@ func TestDeanonymizeResponseBody_ReadError(t *testing.T) {
 	}
 	resp.Header.Set("Content-Type", "application/json")
 	// Should not panic; body should be replaced with empty
-	srv.deanonymizeResponseBody(resp, "test-session")
+	srv.deanonymizeResponseBody(resp, "test-session", "")
 	body, _ := io.ReadAll(resp.Body)
 	if len(body) != 0 {
 		t.Errorf("expected empty body on read error, got %q", string(body))
@@ -1152,7 +1152,7 @@ func TestForward_SetsScheme(t *testing.T) {
 	req.URL.Host = "10.0.0.52:8080"
 
 	w := httptest.NewRecorder()
-	srv.forward(w, req, "")
+	srv.forward(w, req, "", "")
 
 	// Private host gets blocked, but the code path that sets scheme is exercised
 	if w.Code != http.StatusForbidden {
@@ -1311,7 +1311,7 @@ func TestForwardMITMRequest_UpstreamError(t *testing.T) {
 	req.RequestURI = ""
 	rw := httptest.NewRecorder()
 
-	srv.forwardMITMRequest(rw, req, "")
+	srv.forwardMITMRequest(rw, req, "", "")
 
 	if rw.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", rw.Code)


### PR DESCRIPTION
## What

Extracts a `StreamingDeanonymizer` interface so that each AI API provider's SSE format is handled by a dedicated implementation. Previously, `StreamingDeanonymize` hardcoded Anthropic's `content_block_delta` format — non-Anthropic providers fell through to raw string replacement, losing the accumulator-based token-split protection.

## Changes

**Interface + registry** (`streaming_provider.go`):
- `StreamingDeanonymizer` interface: `ProcessDataPayload(payload []byte) bool` + `Flush()`
- `ProviderForDomain(domain)` maps 9 registered domains to 6 provider types
- Factory `NewStreamingDeanonymizer` creates the appropriate implementation

**Provider implementations** (one file each):
- `streaming_anthropic.go` — extracted from `streaming.go` (mechanical move)
- `streaming_openai.go` — `choices[0].delta.content` (covers OpenAI, Mistral, Together, Perplexity, Hugging Face)
- `streaming_gemini.go` — `candidates[0].content.parts[0].text`
- `streaming_cohere.go` — `content-delta` event type with `delta.message.content.text`
- `streaming_replicate.go` — plain text SSE (not JSON)
- `streaming_passthrough.go` — raw replacement fallback for unknown domains

**Framework refactor** (`streaming.go`):
- `streamContext` simplified: removed accumulator fields, added `provider StreamingDeanonymizer`
- `processLine` reduced to ~20 lines — delegates `data:` payloads to provider
- `handleStreamEnd` calls `provider.Flush()` instead of hardcoded flush functions
- Added `writePipe` helper for proper pipe write error handling (stop on first error)

**Proxy threading** (`proxy.go`):
- `domain` parameter threaded through `deanonymizeResponseBody` → `StreamingDeanonymize`
- Both MITM and HTTP paths pass the domain from their existing context

**Documentation** updated: `docs/anonymizer.md` and `docs/architecture.md` reflect multi-provider architecture.

## Quality Gates

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All existing streaming tests pass (35+ Anthropic tests unchanged)
- [x] All new provider tests pass (26 tests across 6 files)
- [x] Coverage: 97.4% overall on `internal/anonymizer`
- [x] Delta coverage: all new files above 90%
- [x] Zero `nolint:errcheck` in new provider files (uses `writePipe` helper)
- [x] Architecture invariants maintained

## Test Plan

- Anthropic: existing 35+ tests via `readStreamResult` (domain=`api.anthropic.com`)
- OpenAI: token split, EOF flush, `[DONE]` sentinel, role-only chunk, finish_reason, verbose logging
- Gemini: token split, EOF flush, empty candidates
- Cohere: token split, EOF flush, non-content event flush
- Replicate: token split, EOF flush, done event, verbose logging
- Passthrough: raw replacement, no-accumulation verification
- Provider registry: all 9 domains + unknown + empty + localhost

## Linked Issues

Closes #52
Related: #102 (nolint:errcheck cleanup for existing code — opened during this PR)