### PR TITLE
fix(make): scope gosec to module packages via go list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:
 
 security:
 	@echo "Running gosec security scanner..."
-	gosec -exclude=G104,G304,G703,G706 ./...
+	gosec -exclude=G104,G304,G703,G706 $$(go list -f '{{.Dir}}' ./...)
 
 vulncheck:
 	@echo "Running govulncheck..."


### PR DESCRIPTION
## What

The `make security` target uses `gosec ./...` which walks the entire filesystem tree, including `.claude/worktrees/` directories. When a worktree exists that references a different API surface (e.g., after a function signature change on another branch), gosec reports spurious build errors from the worktree code.

## Changes

Replace `gosec -exclude=... ./...` with `gosec -exclude=... $(go list -f '{{.Dir}}' ./...)`.

`go list` resolves package directories through the Go module graph, returning only packages that belong to the current module. Worktrees are separate module roots and are naturally excluded without needing a blanket directory exclusion — so worktrees remain fully scannable when gosec is run from within them.

## Quality Gates

- [x] `make check` passed: `All checks passed.`
- [x] gosec scans 28 files / 0 issues (same file count as before, minus stale worktree artifacts)
- [x] No new gosec exclusions added

## Test Plan

- `make security` scans only the current module's packages
- Creating a worktree and running `make security` from within it scans that worktree's packages
- `go list -f '{{.Dir}}' ./...` returns only paths under the current module root