### PR TITLE
feat(anonymizer): handle Managed Agents SSE event types [closes #107]

### DIFF
--- a/internal/anonymizer/streaming_anthropic.go
+++ b/internal/anonymizer/streaming_anthropic.go
@@ -20,6 +20,21 @@ type sseDelta struct {
 	PartialJSON string `json:"partial_json,omitempty"`
 }
 
+// agentContentBlock represents a text block within a Managed Agents event.
+type agentContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// agentEventEnvelope parses agent-level SSE events from the Managed Agents API.
+// Events like agent.message and agent.tool_result carry content arrays with text.
+type agentEventEnvelope struct {
+	Type    string              `json:"type"`
+	ID      string              `json:"id"`
+	Content []agentContentBlock `json:"content,omitempty"`
+	Input   json.RawMessage     `json:"input,omitempty"`
+}
+
 // anthropicDeanonymizer handles Anthropic's SSE format: content_block_delta
 // events with text_delta, thinking_delta, and input_json_delta sub-types.
 type anthropicDeanonymizer struct {
@@ -58,6 +73,12 @@ func (a *anthropicDeanonymizer) ProcessDataPayload(payload []byte) bool {
 	if isJSONDelta {
 		a.processJSONDelta(&envelope)
 		return true
+	}
+
+	// Managed Agents API events: extract and replace text in content blocks.
+	if strings.HasPrefix(envelope.Type, "agent.") {
+		a.Flush()
+		return a.processAgentEvent(payload)
 	}
 
 	// Non-delta event: flush accumulators, then pass through with replacement.
@@ -128,6 +149,104 @@ func (a *anthropicDeanonymizer) processJSONDelta(envelope *sseEnvelope) {
 	remaining := accumulated[flushUpTo:]
 	a.jsonAccum.Reset()
 	a.jsonAccum.WriteString(remaining)
+}
+
+// processAgentEvent handles Managed Agents API events (agent.message,
+// agent.tool_result, agent.mcp_tool_result, agent.tool_use, etc.).
+// Events with content[] arrays get targeted text replacement; tool_use events
+// get raw replacement on the serialized input; all others pass through with
+// raw replacement on the full payload.
+func (a *anthropicDeanonymizer) processAgentEvent(payload []byte) bool {
+	var agent agentEventEnvelope
+	if err := json.Unmarshal(payload, &agent); err != nil {
+		return false
+	}
+
+	switch agent.Type {
+	case "agent.message", "agent.tool_result", "agent.mcp_tool_result":
+		return a.processAgentContentEvent(payload, &agent)
+	case "agent.tool_use", "agent.custom_tool_use", "agent.mcp_tool_use":
+		return a.processAgentInputEvent(payload, &agent)
+	default:
+		// agent.thinking, session.*, span.*, etc. — no text to accumulate.
+		writePipe(a.opts.pw,
+			[]byte(a.opts.replacer.Replace(sseDataPrefix+string(payload))),
+			[]byte("\n"))
+		return true
+	}
+}
+
+// processAgentContentEvent replaces PII tokens in content[].text fields of
+// agent.message, agent.tool_result, and agent.mcp_tool_result events.
+func (a *anthropicDeanonymizer) processAgentContentEvent(payload []byte, agent *agentEventEnvelope) bool {
+	if len(agent.Content) == 0 {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+
+	replaced := false
+	for i := range agent.Content {
+		if agent.Content[i].Type != "text" || agent.Content[i].Text == "" {
+			continue
+		}
+		original := agent.Content[i].Text
+		agent.Content[i].Text = a.opts.replacer.Replace(original)
+		if agent.Content[i].Text != original {
+			replaced = true
+		}
+	}
+
+	if !replaced {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+
+	// Re-serialize from a raw map to preserve all fields we didn't parse.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+	contentBytes, _ := json.Marshal(agent.Content)
+	raw["content"] = contentBytes
+	out, _ := json.Marshal(raw)
+	writePipe(a.opts.pw, []byte(sseDataPrefix), out, []byte("\n"))
+
+	if a.opts.verbose {
+		log.Printf("[DEANON] agent content replaced: sessionID=%s type=%s", a.opts.sessionID, agent.Type)
+	}
+	return true
+}
+
+// processAgentInputEvent replaces PII tokens in the serialized input field
+// of agent.tool_use, agent.custom_tool_use, and agent.mcp_tool_use events.
+func (a *anthropicDeanonymizer) processAgentInputEvent(payload []byte, agent *agentEventEnvelope) bool {
+	if len(agent.Input) == 0 {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+
+	original := string(agent.Input)
+	replaced := a.opts.replacer.Replace(original)
+	if replaced == original {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+
+	// Patch the input field in a raw map to preserve all other fields.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+	raw["input"] = json.RawMessage(replaced)
+	out, _ := json.Marshal(raw)
+	writePipe(a.opts.pw, []byte(sseDataPrefix), out, []byte("\n"))
+
+	if a.opts.verbose {
+		log.Printf("[DEANON] agent input replaced: sessionID=%s type=%s", a.opts.sessionID, agent.Type)
+	}
+	return true
 }
 
 // Flush emits any remaining accumulated text and JSON with token replacement.

--- a/internal/anonymizer/streaming_anthropic.go
+++ b/internal/anonymizer/streaming_anthropic.go
@@ -168,7 +168,7 @@ func (a *anthropicDeanonymizer) processAgentEvent(payload []byte) bool {
 	case "agent.tool_use", "agent.custom_tool_use", "agent.mcp_tool_use":
 		return a.processAgentInputEvent(payload, &agent)
 	default:
-		// agent.thinking, session.*, span.*, etc. — no text to accumulate.
+		// agent.thinking and other unknown agent.* events — no text to accumulate.
 		writePipe(a.opts.pw,
 			[]byte(a.opts.replacer.Replace(sseDataPrefix+string(payload))),
 			[]byte("\n"))
@@ -178,22 +178,56 @@ func (a *anthropicDeanonymizer) processAgentEvent(payload []byte) bool {
 
 // processAgentContentEvent replaces PII tokens in content[].text fields of
 // agent.message, agent.tool_result, and agent.mcp_tool_result events.
-func (a *anthropicDeanonymizer) processAgentContentEvent(payload []byte, agent *agentEventEnvelope) bool {
-	if len(agent.Content) == 0 {
+// It uses raw JSON patching on individual content blocks to preserve all
+// fields on non-text block types (image, document, etc.).
+func (a *anthropicDeanonymizer) processAgentContentEvent(payload []byte, _ *agentEventEnvelope) bool {
+	// Parse the envelope as raw map to preserve all top-level fields.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return false
+	}
+
+	contentRaw, ok := raw["content"]
+	if !ok {
+		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
+		return true
+	}
+
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(contentRaw, &blocks); err != nil || len(blocks) == 0 {
 		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
 		return true
 	}
 
 	replaced := false
-	for i := range agent.Content {
-		if agent.Content[i].Type != "text" || agent.Content[i].Text == "" {
+	for i, block := range blocks {
+		var blockMap map[string]json.RawMessage
+		if err := json.Unmarshal(block, &blockMap); err != nil {
 			continue
 		}
-		original := agent.Content[i].Text
-		agent.Content[i].Text = a.opts.replacer.Replace(original)
-		if agent.Content[i].Text != original {
-			replaced = true
+		typeRaw, hasType := blockMap["type"]
+		textRaw, hasText := blockMap["text"]
+		if !hasType || !hasText {
+			continue
 		}
+
+		var blockType, blockText string
+		if err := json.Unmarshal(typeRaw, &blockType); err != nil || blockType != "text" {
+			continue
+		}
+		if err := json.Unmarshal(textRaw, &blockText); err != nil || blockText == "" {
+			continue
+		}
+
+		newText := a.opts.replacer.Replace(blockText)
+		if newText == blockText {
+			continue
+		}
+
+		replaced = true
+		newTextBytes, _ := json.Marshal(newText)
+		blockMap["text"] = newTextBytes
+		blocks[i], _ = json.Marshal(blockMap)
 	}
 
 	if !replaced {
@@ -201,45 +235,51 @@ func (a *anthropicDeanonymizer) processAgentContentEvent(payload []byte, agent *
 		return true
 	}
 
-	// Re-serialize from a raw map to preserve all fields we didn't parse.
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &raw); err != nil {
-		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
-		return true
-	}
-	contentBytes, _ := json.Marshal(agent.Content)
+	contentBytes, _ := json.Marshal(blocks)
 	raw["content"] = contentBytes
 	out, _ := json.Marshal(raw)
 	writePipe(a.opts.pw, []byte(sseDataPrefix), out, []byte("\n"))
 
 	if a.opts.verbose {
-		log.Printf("[DEANON] agent content replaced: sessionID=%s type=%s", a.opts.sessionID, agent.Type)
+		log.Printf("[DEANON] agent content replaced: sessionID=%s type=%s", a.opts.sessionID, raw["type"])
 	}
 	return true
 }
 
-// processAgentInputEvent replaces PII tokens in the serialized input field
-// of agent.tool_use, agent.custom_tool_use, and agent.mcp_tool_use events.
+// processAgentInputEvent replaces PII tokens in the input field of
+// agent.tool_use, agent.custom_tool_use, and agent.mcp_tool_use events.
+// It parses input as a JSON object, walks all string values with the
+// replacer, and re-serializes to preserve JSON validity when restored
+// PII values contain special characters.
 func (a *anthropicDeanonymizer) processAgentInputEvent(payload []byte, agent *agentEventEnvelope) bool {
 	if len(agent.Input) == 0 {
 		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
 		return true
 	}
 
-	original := string(agent.Input)
-	replaced := a.opts.replacer.Replace(original)
-	if replaced == original {
+	var inputMap map[string]any
+	if err := json.Unmarshal(agent.Input, &inputMap); err != nil {
+		// Not a JSON object — fall back to raw replacement on the full payload.
+		writePipe(a.opts.pw,
+			[]byte(a.opts.replacer.Replace(sseDataPrefix+string(payload))),
+			[]byte("\n"))
+		return true
+	}
+
+	replaced := replaceStringValues(inputMap, a.opts.replacer)
+	if !replaced {
 		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
 		return true
 	}
 
-	// Patch the input field in a raw map to preserve all other fields.
+	// Patch the input field in a raw map to preserve all other envelope fields.
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &raw); err != nil {
 		writePipe(a.opts.pw, []byte(sseDataPrefix), payload, []byte("\n"))
 		return true
 	}
-	raw["input"] = json.RawMessage(replaced)
+	inputBytes, _ := json.Marshal(inputMap)
+	raw["input"] = inputBytes
 	out, _ := json.Marshal(raw)
 	writePipe(a.opts.pw, []byte(sseDataPrefix), out, []byte("\n"))
 
@@ -247,6 +287,56 @@ func (a *anthropicDeanonymizer) processAgentInputEvent(payload []byte, agent *ag
 		log.Printf("[DEANON] agent input replaced: sessionID=%s type=%s", a.opts.sessionID, agent.Type)
 	}
 	return true
+}
+
+// replaceStringValues recursively walks a parsed JSON object and applies
+// the replacer to all string values. Returns true if any value was changed.
+func replaceStringValues(obj map[string]any, replacer *strings.Replacer) bool {
+	changed := false
+	for k, v := range obj {
+		switch val := v.(type) {
+		case string:
+			replaced := replacer.Replace(val)
+			if replaced != val {
+				obj[k] = replaced
+				changed = true
+			}
+		case map[string]any:
+			if replaceStringValues(val, replacer) {
+				changed = true
+			}
+		case []any:
+			if replaceSliceValues(val, replacer) {
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// replaceSliceValues recursively walks a JSON array and applies the
+// replacer to all string values. Returns true if any value was changed.
+func replaceSliceValues(arr []any, replacer *strings.Replacer) bool {
+	changed := false
+	for i, v := range arr {
+		switch val := v.(type) {
+		case string:
+			replaced := replacer.Replace(val)
+			if replaced != val {
+				arr[i] = replaced
+				changed = true
+			}
+		case map[string]any:
+			if replaceStringValues(val, replacer) {
+				changed = true
+			}
+		case []any:
+			if replaceSliceValues(val, replacer) {
+				changed = true
+			}
+		}
+	}
+	return changed
 }
 
 // Flush emits any remaining accumulated text and JSON with token replacement.

--- a/internal/anonymizer/streaming_anthropic_test.go
+++ b/internal/anonymizer/streaming_anthropic_test.go
@@ -1,0 +1,336 @@
+package anonymizer
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// --- Managed Agents API event tests (issue #107) ---
+
+// makeAgentMessage builds an SSE line for an agent.message event with text content.
+func makeAgentMessage(texts ...string) string {
+	content := make([]agentContentBlock, len(texts))
+	for i, t := range texts {
+		content[i] = agentContentBlock{Type: "text", Text: t}
+	}
+	event := map[string]any{
+		"type":         "agent.message",
+		"id":           "evt_test_123",
+		"content":      content,
+		"processed_at": "2026-05-01T10:00:00Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+// makeAgentToolResult builds an SSE line for an agent.tool_result event.
+func makeAgentToolResult(texts ...string) string {
+	content := make([]agentContentBlock, len(texts))
+	for i, t := range texts {
+		content[i] = agentContentBlock{Type: "text", Text: t}
+	}
+	event := map[string]any{
+		"type":         "agent.tool_result",
+		"id":           "evt_test_456",
+		"tool_use_id":  "tu_test_789",
+		"content":      content,
+		"processed_at": "2026-05-01T10:00:01Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+// makeAgentMCPToolResult builds an SSE line for an agent.mcp_tool_result event.
+func makeAgentMCPToolResult(texts ...string) string {
+	content := make([]agentContentBlock, len(texts))
+	for i, t := range texts {
+		content[i] = agentContentBlock{Type: "text", Text: t}
+	}
+	event := map[string]any{
+		"type":            "agent.mcp_tool_result",
+		"id":              "evt_test_mcp",
+		"mcp_tool_use_id": "mtu_test_101",
+		"content":         content,
+		"processed_at":    "2026-05-01T10:00:02Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+// makeAgentToolUse builds an SSE line for an agent.tool_use event with input.
+func makeAgentToolUse(name string, input map[string]any) string {
+	event := map[string]any{
+		"type":         "agent.tool_use",
+		"id":           "evt_test_tu",
+		"name":         name,
+		"input":        input,
+		"processed_at": "2026-05-01T10:00:03Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+// makeAgentCustomToolUse builds an SSE line for an agent.custom_tool_use event.
+func makeAgentCustomToolUse(name string, input map[string]any) string {
+	event := map[string]any{
+		"type":         "agent.custom_tool_use",
+		"id":           "evt_test_ctu",
+		"name":         name,
+		"input":        input,
+		"processed_at": "2026-05-01T10:00:04Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+// makeAgentThinking builds an SSE line for an agent.thinking event (no text).
+func makeAgentThinking() string {
+	event := map[string]any{
+		"type":         "agent.thinking",
+		"id":           "evt_test_think",
+		"processed_at": "2026-05-01T10:00:05Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+func TestAgentMessageTokenReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	sseInput := makeAgentMessage("Hello " + token + " how are you?")
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("agent.message token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("agent.message still contains token:\n%s", got)
+	}
+}
+
+func TestAgentMessageMultipleContentBlocks(t *testing.T) {
+	token1 := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	token2 := "[PII_PHONE_a1b2c3d4e5f6a7b8]"
+	tokenMap := map[string]string{
+		token1: "earl@example.com",
+		token2: "+49 170 1234567",
+	}
+
+	sseInput := makeAgentMessage("Contact: "+token1, "Phone: "+token2)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if strings.Contains(got, token1) {
+		t.Errorf("token1 not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token2) {
+		t.Errorf("token2 not replaced:\n%s", got)
+	}
+	if !strings.Contains(got, "earl@example.com") {
+		t.Errorf("original1 not present:\n%s", got)
+	}
+	if !strings.Contains(got, "+49 170 1234567") {
+		t.Errorf("original2 not present:\n%s", got)
+	}
+}
+
+func TestAgentToolResultTokenReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	sseInput := makeAgentToolResult("File content: " + token)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("agent.tool_result token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("agent.tool_result still contains token:\n%s", got)
+	}
+}
+
+func TestAgentMCPToolResultTokenReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	sseInput := makeAgentMCPToolResult("Result: " + token)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("agent.mcp_tool_result token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("agent.mcp_tool_result still contains token:\n%s", got)
+	}
+}
+
+func TestAgentToolUseInputReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	input := map[string]any{"query": "search for " + token}
+	sseInput := makeAgentToolUse("web_search", input)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("agent.tool_use input token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("agent.tool_use still contains token:\n%s", got)
+	}
+}
+
+func TestAgentCustomToolUseInputReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	input := map[string]any{"email": token}
+	sseInput := makeAgentCustomToolUse("send_email", input)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("agent.custom_tool_use input token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("agent.custom_tool_use still contains token:\n%s", got)
+	}
+}
+
+func TestAgentThinkingPassthrough(t *testing.T) {
+	tokenMap := map[string]string{}
+
+	sseInput := makeAgentThinking()
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, "agent.thinking") {
+		t.Errorf("agent.thinking event not passed through:\n%s", got)
+	}
+}
+
+func TestAgentMessageNoTokenNoMutation(t *testing.T) {
+	tokenMap := map[string]string{"[PII_EMAIL_c160f8cc4b2e1a3d]": "earl@example.com"}
+
+	sseInput := makeAgentMessage("Hello world, no PII here")
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, "Hello world, no PII here") {
+		t.Errorf("text mutated when no token present:\n%s", got)
+	}
+}
+
+func TestAgentMessageEmptyContent(t *testing.T) {
+	// agent.message with empty content array should pass through cleanly.
+	event := map[string]any{
+		"type":         "agent.message",
+		"id":           "evt_empty",
+		"content":      []agentContentBlock{},
+		"processed_at": "2026-05-01T10:00:00Z",
+	}
+	b, _ := json.Marshal(event)
+	sseInput := "data: " + string(b) + "\n"
+
+	tokenMap := map[string]string{"[PII_EMAIL_c160f8cc4b2e1a3d]": "earl@example.com"}
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, "agent.message") {
+		t.Errorf("empty content event not passed through:\n%s", got)
+	}
+}
+
+func TestAgentUnknownEventPassthrough(t *testing.T) {
+	// A future/unknown agent event type should still pass through with raw replacement.
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	event := map[string]any{
+		"type":         "agent.future_event",
+		"id":           "evt_future",
+		"data":         "some data with " + token,
+		"processed_at": "2026-05-01T10:00:00Z",
+	}
+	b, _ := json.Marshal(event)
+	sseInput := "data: " + string(b) + "\n"
+
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("unknown agent event token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("unknown agent event still contains token:\n%s", got)
+	}
+}
+
+func TestMixedStreamAgentAndDelta(t *testing.T) {
+	// Verify that standard content_block_delta and agent events interleave correctly.
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("x", tokenSuffixLen+10)
+	sseInput := makeSSETextDelta(prefix+token+" hello") +
+		makeAgentMessage("Agent says: "+token) +
+		"\n"
+
+	got := readStreamResult(t, sseInput, tokenMap)
+
+	// Both occurrences should be replaced.
+	if strings.Contains(got, token) {
+		t.Errorf("mixed stream still contains token:\n%s", got)
+	}
+	count := strings.Count(got, original)
+	if count < 2 {
+		t.Errorf("expected at least 2 replacements, got %d:\n%s", count, got)
+	}
+}
+
+// --- Regression tests for existing content_block_delta handling ---
+
+func TestContentBlockDeltaTextReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("a", tokenSuffixLen+10)
+	sseInput := makeSSETextDelta(prefix+token+" done") + "\n"
+
+	got := readStreamResult(t, sseInput, tokenMap)
+	if !strings.Contains(got, original) {
+		t.Errorf("text_delta token not replaced:\n%s", got)
+	}
+}
+
+func TestContentBlockDeltaThinkingReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("a", tokenSuffixLen+10)
+	sseInput := makeSSEThinkingDelta(prefix+token+" thought") + "\n"
+
+	got := readStreamResult(t, sseInput, tokenMap)
+	if !strings.Contains(got, original) {
+		t.Errorf("thinking_delta token not replaced:\n%s", got)
+	}
+}
+
+func TestContentBlockDeltaJSONReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	prefix := strings.Repeat("a", tokenSuffixLen+10)
+	sseInput := makeSSEJsonDelta(prefix+token) + "\n"
+
+	got := readStreamResult(t, sseInput, tokenMap)
+	if !strings.Contains(got, original) {
+		t.Errorf("input_json_delta token not replaced:\n%s", got)
+	}
+}

--- a/internal/anonymizer/streaming_anthropic_test.go
+++ b/internal/anonymizer/streaming_anthropic_test.go
@@ -202,6 +202,93 @@ func TestAgentCustomToolUseInputReplacement(t *testing.T) {
 	}
 }
 
+// makeAgentMCPToolUse builds an SSE line for an agent.mcp_tool_use event.
+func makeAgentMCPToolUse(name string, input map[string]any) string {
+	event := map[string]any{
+		"type":            "agent.mcp_tool_use",
+		"id":              "evt_test_mtu",
+		"name":            name,
+		"mcp_server_name": "test-server",
+		"input":           input,
+		"processed_at":    "2026-05-01T10:00:06Z",
+	}
+	b, _ := json.Marshal(event)
+	return "data: " + string(b) + "\n"
+}
+
+func TestAgentMCPToolUseInputReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	input := map[string]any{"query": "find " + token}
+	sseInput := makeAgentMCPToolUse("search_docs", input)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if !strings.Contains(got, original) {
+		t.Errorf("agent.mcp_tool_use input token not replaced:\n%s", got)
+	}
+	if strings.Contains(got, token) {
+		t.Errorf("agent.mcp_tool_use still contains token:\n%s", got)
+	}
+}
+
+func TestAgentToolUseNestedInputReplacement(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	input := map[string]any{
+		"options": map[string]any{
+			"recipient": token,
+			"cc":        []any{"other@example.com", token},
+		},
+	}
+	sseInput := makeAgentToolUse("send_email", input)
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if strings.Contains(got, token) {
+		t.Errorf("nested input token not replaced:\n%s", got)
+	}
+}
+
+func TestAgentMessageMixedContentBlocks(t *testing.T) {
+	// Verify that non-text content blocks (image, document) are preserved
+	// when a text block in the same array triggers replacement.
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	event := map[string]any{
+		"type": "agent.message",
+		"id":   "evt_mixed",
+		"content": []map[string]any{
+			{"type": "text", "text": "Hello " + token},
+			{"type": "image", "source": map[string]any{"type": "url", "url": "https://example.com/img.png"}},
+			{"type": "text", "text": "No PII here"},
+		},
+		"processed_at": "2026-05-01T10:00:00Z",
+	}
+	b, _ := json.Marshal(event)
+	sseInput := "data: " + string(b) + "\n"
+
+	got := readStreamResult(t, sseInput+"\n", tokenMap)
+
+	if strings.Contains(got, token) {
+		t.Errorf("token not replaced in mixed content:\n%s", got)
+	}
+	if !strings.Contains(got, original) {
+		t.Errorf("original not present in mixed content:\n%s", got)
+	}
+	// The image block must survive re-serialization.
+	if !strings.Contains(got, "https://example.com/img.png") {
+		t.Errorf("image block lost during re-serialization:\n%s", got)
+	}
+	if !strings.Contains(got, "No PII here") {
+		t.Errorf("second text block lost:\n%s", got)
+	}
+}
+
 func TestAgentThinkingPassthrough(t *testing.T) {
 	tokenMap := map[string]string{}
 


### PR DESCRIPTION
## What

Anthropic's Managed Agents API (beta: `managed-agents-2026-04-01`) emits agent-level SSE events with a different JSON schema than the standard Messages API. Without explicit handling, PII tokens in `content[].text` fields of agent events could leak through if they match JSON structure rather than raw text.

## Changes

- Add `agentContentBlock` / `agentEventEnvelope` structs to parse agent events
- Route `agent.*` event types to targeted handlers in `ProcessDataPayload`
- `agent.message` / `agent.tool_result` / `agent.mcp_tool_result`: extract and replace PII tokens in `content[].text` fields, re-serialize preserving all other fields
- `agent.tool_use` / `agent.custom_tool_use` / `agent.mcp_tool_use`: replace tokens in serialized `input` field
- `agent.thinking` and unknown `agent.*` events: raw replacement passthrough (defense in depth)
- 14 new tests covering all agent event types, mixed streams, and regressions

## Quality Gates

- [x] `make check` passed: `All checks passed.`
- [x] `go test -race ./...` passed
- [x] gosec: 0 issues (28 files scanned)
- [x] govulncheck: no vulnerabilities
- [x] Architecture invariants maintained

## Test Plan

- Each agent event type tested with PII tokens in text fields
- Empty content arrays pass through without mutation
- Unknown future agent event types get raw replacement fallback
- Mixed stream (standard content_block_delta + agent events) works correctly
- Regression tests for existing text_delta, thinking_delta, input_json_delta

## Linked Issues

Closes #107