### PR TITLE
chore(ci,lint): fix delta-coverage silent-skip + remove dead nolint:gocritic [closes #116]

### DIFF
--- a/.github/scripts/delta-coverage.sh
+++ b/.github/scripts/delta-coverage.sh
@@ -15,8 +15,17 @@ if [ ! -f "$COVERAGE_FILE" ]; then
   exit 1
 fi
 
-# Get changed .go source files (exclude tests, generated, mocks)
-changed_files=$(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD" -- '*.go' \
+# Get changed .go source files (exclude tests, generated, mocks).
+# Fail closed: if `git diff` cannot resolve the merge base (e.g. shallow clone
+# without enough history), we MUST exit non-zero so the CI job fails loudly
+# rather than silently bypassing the delta gate.
+if ! diff_output=$(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD" -- '*.go'); then
+  echo "ERROR: git diff failed against ${BASE_REF}...HEAD — cannot compute changed files." >&2
+  echo "  Check that the workflow's actions/checkout step uses fetch-depth: 0 so the merge base is reachable." >&2
+  exit 1
+fi
+
+changed_files=$(echo "$diff_output" \
   | grep -v '_test\.go$' \
   | grep -v '_generated\.go$' \
   | grep -v 'mock_' \
@@ -51,6 +60,18 @@ while IFS= read -r file; do
 
     # Skip the total line
     if [ "$func_name" = "(statements)" ]; then
+      continue
+    fi
+
+    # `go tool cover -func` reports 0.0% for functions with zero instrumented
+    # statements (e.g. empty interface-compliance methods). That's not a
+    # coverage failure — it's a 0-of-0 ratio. Detect by summing numStmts from
+    # all blocks in the raw profile whose start line equals the function's
+    # declaration line. If the sum is 0, the function has nothing to cover.
+    func_start_line=$(echo "$line" | awk -F: '{print $2}')
+    stmt_sum=$(grep -E "/${file}:${func_start_line}\." "$COVERAGE_FILE" \
+      | awk '{sum += $2} END {print sum+0}')
+    if [ "$stmt_sum" = "0" ]; then
       continue
     fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history required so delta-coverage.sh can resolve the merge
+          # base against origin/main. Without this, git diff exits non-zero
+          # and the delta gate fails loudly (see delta-coverage.sh).
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/internal/anonymizer/streaming_passthrough.go
+++ b/internal/anonymizer/streaming_passthrough.go
@@ -20,4 +20,5 @@ func (p *passthroughDeanonymizer) ProcessDataPayload(payload []byte) bool {
 }
 
 // Flush is a no-op — passthrough does not accumulate state between payloads.
-func (p *passthroughDeanonymizer) Flush() {} //nolint:gocritic // interface compliance; no state to flush
+// Required for streamDeanonymizer interface compliance.
+func (p *passthroughDeanonymizer) Flush() {}

--- a/internal/anonymizer/streaming_passthrough_test.go
+++ b/internal/anonymizer/streaming_passthrough_test.go
@@ -43,6 +43,14 @@ func TestPassthroughFlushIsNoOp(t *testing.T) {
 	}
 }
 
+// TestPassthroughFlushDirect calls Flush directly on the deanonymizer to pin
+// the no-op contract (and to ensure the function body is exercised for the
+// delta-coverage gate).
+func TestPassthroughFlushDirect(t *testing.T) {
+	d := &passthroughDeanonymizer{}
+	d.Flush()
+}
+
 // TestPassthroughStreamingNoAccumulation verifies that the passthrough provider
 // does not rejoin tokens split across events — this is the documented trade-off
 // for unknown providers. Because passthroughDeanonymizer writes each event

--- a/internal/anonymizer/streaming_passthrough_test.go
+++ b/internal/anonymizer/streaming_passthrough_test.go
@@ -44,9 +44,9 @@ func TestPassthroughFlushIsNoOp(t *testing.T) {
 }
 
 // TestPassthroughFlushDirect calls Flush directly on the deanonymizer to pin
-// the no-op contract (and to ensure the function body is exercised for the
-// delta-coverage gate).
-func TestPassthroughFlushDirect(t *testing.T) {
+// the no-op contract. The function body is empty, so this test asserts only
+// that the call does not panic.
+func TestPassthroughFlushDirect(_ *testing.T) {
 	d := &passthroughDeanonymizer{}
 	d.Flush()
 }


### PR DESCRIPTION
# Pull Request

## What

Two gate-integrity cleanups bundled into a single chore PR. (1) Removes a dead `//nolint:gocritic` directive — the `gocritic` linter is not enabled in `.golangci.yml`, so the suppression was no-op and violated the new CLAUDE.md "No hacks" clause (#116). (2) Fixes a silent-skip in `.github/scripts/delta-coverage.sh` where a shallow clone caused `git diff` to fail, `|| true` swallowed the error, and the script exited 0 with `delta coverage check skipped` — silently bypassing the 95%/90% delta gate while the Test job stayed green.

This PR is the first concrete demonstration of the new CLAUDE.md "No hacks" clause: it removes a hack rather than adding one, and prevents a future hack-style silent skip in the CI gate.

## Changes

- `internal/anonymizer/streaming_passthrough.go` — remove the `//nolint:gocritic` directive on `Flush`. Moved the explanatory text into godoc above the function (no behavior change). The `gocritic` linter is not in `.golangci.yml`'s enabled list, so the directive suppressed nothing.
- `internal/anonymizer/streaming_passthrough_test.go` — add `TestPassthroughFlushDirect` that calls `Flush()` directly to pin the no-op contract. Parameter named `_` (revive's `allowRegex: ^_` accepts this) since the test asserts only non-panic.
- `.github/workflows/ci.yml` — **Layer 1 fix:** add `fetch-depth: 0` to the test job's `actions/checkout` step so the merge base against `origin/main` is always reachable. (The existing `git fetch origin main --depth=50` step is now redundant but harmless; kept to avoid touching unrelated infra.)
- `.github/scripts/delta-coverage.sh` — **Layer 2 fix:** replace `|| true` on the `git diff` line with explicit `if !` error handling. The script now exits 1 with a clear message ("Check that the workflow's actions/checkout step uses fetch-depth: 0…") when the merge base can't be resolved, instead of silently exiting 0. Any future regression (e.g. someone re-shallowing the clone for cache reasons) will fail loudly.
- `.github/scripts/delta-coverage.sh` — handle 0-statement functions correctly. `go tool cover -func` reports `0.0%` for empty interface-compliance methods (like `Flush`) because the ratio is 0-of-0. Without this fix, removing the nolint would have caused delta-coverage to false-fail on `Flush`. The script now sums `numStmts` from the raw cover profile blocks at the function's start line; if the sum is 0, the per-function check is skipped (a 0-of-0 ratio is not a coverage failure). The explicit `TestPassthroughFlushDirect` test pins the no-op regardless.

## Quality Gates

- [x] `make check` passed locally (lint, test, security, vulncheck — all four sub-gates exit 0). Last line of output:
  `All checks passed.`
- [x] `go test -race ./...` passed (covered by `make check`'s test sub-target).
- [x] Coverage minimums met: `internal/anonymizer` 95.4% ≥ 95%, `internal/config` 100.0% ≥ 95%, `internal/anonymizer/packs` 97.6% ≥ 95%, overall 92.7% ≥ 85%.
- [x] Delta coverage ≥90% on all changed/new files — see [Delta Coverage Report](#delta-coverage-report) below.
- [x] [§6 Test Inventory baseline-vs-head](#6-test-inventory--baseline-vs-head) completed below.
- [x] No hacks introduced. This PR REMOVES a hack (the dead `//nolint:gocritic`) and PREVENTS a future hack-style silent-skip (the `|| true` swallow + the 0-statement false-fail trap). No `//nolint`, no `t.Skip()`, no `// coverage-ignore`, no new `gosec` exclusions, no hardcoded values added.
- [x] All CI jobs green at the PR head SHA (pending CI run on push).

## Delta Coverage Report

Per `.github/scripts/delta-coverage.sh` — every function in changed/new `.go` source files (excluding `_test.go`, `_generated.go`, `mock_*`) must be ≥90%.

**Command:**

```bash
go test -race -coverprofile=coverage.out -covermode=atomic ./...
bash .github/scripts/delta-coverage.sh coverage.out 90.0 origin/main
```

**Raw script output:**

```text
=== Delta Coverage Check (threshold: 90.0%) ===

Changed source files:
  internal/anonymizer/streaming_passthrough.go


Checked 2 functions in 1 changed files.
SUCCESS: All functions in changed files meet 90.0% coverage threshold.
```

**Per-function table** — `internal/anonymizer/streaming_passthrough.go`:

| File | Function | Coverage % | ≥90% |
|---|---|---|---|
| `internal/anonymizer/streaming_passthrough.go` | `newPassthroughDeanonymizer` | 100.0% | ✅ |
| `internal/anonymizer/streaming_passthrough.go` | `ProcessDataPayload` | 100.0% | ✅ |
| `internal/anonymizer/streaming_passthrough.go` | `Flush` | 0/0 statements (N/A — empty body, pinned by `TestPassthroughFlushDirect`) | ✅ (skipped by script's 0-statement guard) |

The `Flush` row is the case the script's new 0-statement guard is built to handle correctly: `go tool cover -func` reports `0.0%` because the empty body has zero instrumented statements, but the ratio is 0-of-0 (trivially perfect), not 0-of-N (a real gap). `TestPassthroughFlushDirect` asserts non-panic. See `.github/scripts/delta-coverage.sh` lines for the guard.

## Bug Reproduction (delta-coverage silent-skip)

Reproduced locally by cloning the repo shallow (`--depth=1`) and running the **old** script vs the **new** script against the same `coverage.out`:

```text
=== OLD script on shallow clone (the bug): ===
fatal: bad revision 'origin/main...HEAD'
No changed Go source files — delta coverage check skipped.
EXIT=0                  ← silently bypasses the gate

=== NEW script on shallow clone (fail-closed): ===
fatal: bad revision 'origin/main...HEAD'
ERROR: git diff failed against origin/main...HEAD — cannot compute changed files.
  Check that the workflow's actions/checkout step uses fetch-depth: 0 so the merge base is reachable.
EXIT=1                  ← fails loudly, blocks merge
```

In CI the Layer 1 fix (`fetch-depth: 0`) means the merge base is always reachable, so the Layer 2 guard never trips in normal operation. Layer 2 exists so that any future regression of Layer 1 is caught loudly instead of silently.

## §6 Test Inventory — baseline vs head

Method: checkout `main`, run `go test -race -count=1 -v <pkg>` and count `--- PASS` / `--- FAIL` lines (top-level + subtests). Repeat on the PR head SHA. Zero failures on either side.

| Package | main (`917701b`) PASS / FAIL | head (`0b867fb`) PASS / FAIL | Delta |
|---|---|---|---|
| `./cmd/proxy/` | 4 / 0 | 4 / 0 | 0 |
| `./internal/anonymizer/` | 199 / 0 | 200 / 0 | +1 (new `TestPassthroughFlushDirect`) |
| `./internal/anonymizer/packs/` | 71 / 0 | 71 / 0 | 0 |
| `./internal/config/` | 33 / 0 | 33 / 0 | 0 |
| `./internal/logger/` | 11 / 0 | 11 / 0 | 0 |
| `./internal/management/` | 38 / 0 | 38 / 0 | 0 |
| `./internal/metrics/` | 17 / 0 | 17 / 0 | 0 |
| `./internal/mitm/` | 30 / 0 | 30 / 0 | 0 |
| `./internal/proxy/` | 59 / 0 | 59 / 0 | 0 |
| `./internal/domainmatch/` | 5 / 0 | 5 / 0 | 0 |

Zero failures on either side. Net delta: +1 PASS in `internal/anonymizer` from the new direct `Flush` unit test. No removals.

## Test Plan

- `TestPassthroughFlushDirect` (new) — pins `Flush()` as a non-panic no-op. Asserts the interface-compliance contract regardless of whether `go tool cover` instruments the empty body.
- Existing `TestPassthroughFlushIsNoOp` / `TestPassthroughStreamingReplacement` / `TestPassthroughStreamingNoAccumulation` continue to pin the passthrough provider's streaming behavior end-to-end.
- Delta-coverage script: validated locally (1) against this branch's coverage profile (passes), (2) against a deliberately-shallow clone using the OLD script (reproduces silent-skip with exit 0) and the NEW script (fails loudly with exit 1 and explicit guidance).

## Linked Issues

Closes #116


---
_Generated by [Claude Code](https://claude.ai/code/session_018yDmaobDNb4k3wuNUL4Y3j)_