### PR TITLE
feat(config): add Cloudflare AI Gateway domain

### DIFF
--- a/internal/anonymizer/streaming_cloudflare_test.go
+++ b/internal/anonymizer/streaming_cloudflare_test.go
@@ -1,0 +1,78 @@
+package anonymizer
+
+import (
+	"strings"
+	"testing"
+)
+
+// cloudflareGatewayDomain is the Cloudflare AI Gateway domain. It is
+// registered with ProviderPassthrough because the gateway proxies to
+// multiple upstream providers (OpenAI, Anthropic, Google, etc.) behind a
+// single domain, with the SSE format determined by the path. The proxy
+// routes streaming format by domain only, so passthrough (raw token
+// replacement) is the safe default that works regardless of which
+// upstream format is in use.
+const cloudflareGatewayDomain = "gateway.ai.cloudflare.com"
+
+// TestCloudflarePassthroughDeanonymize verifies passthrough token
+// replacement works on the three plausible SSE shapes returned through
+// Cloudflare AI Gateway: OpenAI-style (via /compat/ or /openai/),
+// Anthropic-style (via /anthropic/), and plain text. The proxy cannot
+// distinguish the upstream format from the destination domain, so the
+// passthrough deanonymizer must handle all of them.
+func TestCloudflarePassthroughDeanonymize(t *testing.T) {
+	token := "[PII_EMAIL_c160f8cc4b2e1a3d]"
+	original := "earl@example.com"
+	tokenMap := map[string]string{token: original}
+
+	tests := []struct {
+		name     string
+		sseInput string
+	}{
+		{
+			name: "openai_format",
+			sseInput: "data: {\"choices\":[{\"delta\":{\"content\":\"Hello " + token + "\"}}]}\n\n" +
+				"data: [DONE]\n\n",
+		},
+		{
+			name: "anthropic_format",
+			sseInput: "event: content_block_delta\n" +
+				"data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello " + token + "\"}}\n\n",
+		},
+		{
+			name:     "plain_text",
+			sseInput: "data: The email is " + token + "\n\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readStreamResultForDomain(t, tc.sseInput, tokenMap, cloudflareGatewayDomain)
+			if !strings.Contains(got, original) {
+				t.Errorf("Cloudflare passthrough %s: token not replaced:\n%s", tc.name, got)
+			}
+			if strings.Contains(got, token) {
+				t.Errorf("Cloudflare passthrough %s: unreplaced token:\n%s", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestCloudflareNonStreamingAnonymize verifies that non-streaming
+// (buffered) request body anonymization works for a Cloudflare-routed
+// request, and that DeanonymizeText restores the original value.
+func TestCloudflareNonStreamingAnonymize(t *testing.T) {
+	a := newTestAnonymizer()
+	sessionID := "sess-cloudflare-1"
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"Summarize the report by test@example.com"}]}`)
+
+	anonymized := a.AnonymizeJSON(body, sessionID)
+	if strings.Contains(string(anonymized), "test@example.com") {
+		t.Errorf("email not anonymized in Cloudflare request body: %s", anonymized)
+	}
+
+	restored := a.DeanonymizeText(string(anonymized), sessionID)
+	if !strings.Contains(restored, "test@example.com") {
+		t.Errorf("email not restored after deanonymization: %s", restored)
+	}
+}

--- a/internal/anonymizer/streaming_provider.go
+++ b/internal/anonymizer/streaming_provider.go
@@ -70,6 +70,13 @@ var domainToProvider = map[string]Provider{
 	"openrouter.ai":                     ProviderOpenAI,
 	"api.portkey.ai":                    ProviderOpenAI,
 	"api.githubcopilot.com":             ProviderPassthrough,
+	// Cloudflare AI Gateway proxies to multiple upstream providers
+	// (OpenAI, Anthropic, Google, etc.) behind a single domain, with the
+	// SSE format determined by the path (.../openai/..., .../anthropic/...,
+	// .../compat/...). The proxy routes by domain only, so passthrough
+	// (raw token replacement) is the safe default that works regardless
+	// of which upstream format is in use.
+	"gateway.ai.cloudflare.com": ProviderPassthrough,
 }
 
 // globProviders maps segment-glob domain patterns to their streaming format.

--- a/internal/anonymizer/streaming_provider_test.go
+++ b/internal/anonymizer/streaming_provider_test.go
@@ -73,6 +73,11 @@ func TestProviderForDomain(t *testing.T) {
 		{"api.portkey.ai", ProviderOpenAI},
 		// Phase 4: GitHub Copilot proprietary REST format — passthrough
 		{"api.githubcopilot.com", ProviderPassthrough},
+		// Phase 5: Cloudflare AI Gateway — passthrough (multiple upstream
+		// formats behind one domain).
+		{"gateway.ai.cloudflare.com", ProviderPassthrough},
+		{"GATEWAY.AI.CLOUDFLARE.COM", ProviderPassthrough},
+		{"gateway.ai.cloudflare.com.", ProviderPassthrough},
 		// Phase 3: prefix wildcards (Azure, Vertex)
 		{"myresource.openai.azure.com", ProviderOpenAI},
 		{"eastus2.openai.azure.com", ProviderOpenAI},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,10 @@ func defaults() *Config {
 			"openrouter.ai",
 			"api.portkey.ai",
 			"api.githubcopilot.com",
+			// Cloudflare AI Gateway: fixed domain with user-specific path
+			// segments (/v1/{account_id}/{gateway_id}/...). The proxy
+			// routes by domain only, so the variable paths don't matter.
+			"gateway.ai.cloudflare.com",
 			// Azure OpenAI: {resource}.openai.azure.com
 			"*.openai.azure.com",
 			// Vertex AI:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -407,6 +407,22 @@ func TestCopilotDomainRegistered(t *testing.T) {
 	}
 }
 
+// TestCloudflareGatewayDomainRegistered verifies the Cloudflare AI Gateway
+// domain appears in the default AIAPIDomains slice.
+func TestCloudflareGatewayDomainRegistered(t *testing.T) {
+	cfg := defaults()
+	found := false
+	for _, d := range cfg.AIAPIDomains {
+		if d == "gateway.ai.cloudflare.com" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("gateway.ai.cloudflare.com not in default AIAPIDomains")
+	}
+}
+
 // TestGitHubAuthDomainRegistered verifies github.com appears in the default
 // AuthDomains slice so Copilot's device-auth flow bypasses anonymization.
 func TestGitHubAuthDomainRegistered(t *testing.T) {


### PR DESCRIPTION
## What
Add Cloudflare AI Gateway domain with passthrough deanonymization.

Cloudflare AI Gateway uses a fixed domain (`gateway.ai.cloudflare.com`) with user-specific path segments (`/v1/{account_id}/{gateway_id}/...`) and exposes multiple upstream formats behind the same domain — `/compat/chat/completions` (OpenAI-shaped), `/openai/...`, `/anthropic/...`, `/google-ai-studio/...`. Since the proxy routes streaming format by domain (not path), `ProviderPassthrough` is the safe default — raw token replacement works on any SSE text format regardless of which upstream Cloudflare routes to.

## Changes
- `internal/config/config.go`: added `gateway.ai.cloudflare.com` to `AIAPIDomains`
- `internal/anonymizer/streaming_provider.go`: mapped the domain to `ProviderPassthrough` in `domainToProvider`
- `internal/anonymizer/streaming_provider_test.go`: added domain to `TestProviderForDomain` (exact, uppercase, trailing-dot)
- `internal/config/config_test.go`: added `TestCloudflareGatewayDomainRegistered`
- `internal/anonymizer/streaming_cloudflare_test.go` (new): `TestCloudflarePassthroughDeanonymize` (OpenAI / Anthropic / plain-text SSE) and `TestCloudflareNonStreamingAnonymize` (request body round-trip)

## Baseline Issues
- `TestDispatchOllamaAsyncWithMockServer` (`internal/anonymizer/anonymizer_test.go:1329`) is flaky on `main` — it busy-loops with `runtime.Gosched()` waiting for an async goroutine and intermittently times out the polling window. Observed failing on both `main` HEAD (`b9eff1a`) and PR head (`0ae19a2`) when `make check` runs the package with cache disabled; passes consistently on isolated per-package re-runs (used for the §6 inventory below). Not caused by this PR.

## Quality Gates
- [x] `make check` passed (`All checks passed.`, exit 0) — re-run after the baseline flake cleared
- [x] `go test -race ./...` — all 10 packages `ok`, zero failures
- [x] No regressions vs baseline
- [x] Coverage minimums (gate #3): `internal/config` 100.0%, `internal/anonymizer` 95.6%, `internal/anonymizer/packs` 97.6%, overall 96.2% (all above 95%/85% floors)
- [x] Delta coverage ≥ 90% on changed files (gate #4): see per-function table below

## Delta Coverage (gate #4) — per file, per function

Reproduces what `.github/scripts/delta-coverage.sh coverage.out 90.0 origin/main` checks. Source: `go tool cover -func=coverage.out` filtered to `git diff --name-only origin/main...HEAD` non-test `.go` files.

Changed source files (matches the script's `changed_files`):
- `internal/anonymizer/streaming_provider.go`
- `internal/config/config.go`

| File | Function | Coverage |
|---|---|---:|
| `internal/anonymizer/streaming_provider.go` | `ProviderForDomain` | 100.0% |
| `internal/anonymizer/streaming_provider.go` | `NewStreamingDeanonymizer` | 100.0% |
| `internal/config/config.go` | `Load` | 100.0% |
| `internal/config/config.go` | `defaults` | 100.0% |
| `internal/config/config.go` | `loadEnvStringSlice` | 100.0% |
| `internal/config/config.go` | `ResolvePIIInstruction` | 100.0% |
| `internal/config/config.go` | `loadFile` | 100.0% |
| `internal/config/config.go` | `loadEnvString` | 100.0% |
| `internal/config/config.go` | `loadEnvInt` | 100.0% |
| `internal/config/config.go` | `loadEnvIntPositive` | 100.0% |
| `internal/config/config.go` | `loadEnvFloat` | 100.0% |
| `internal/config/config.go` | `loadEnvBoolFalse` | 100.0% |
| `internal/config/config.go` | `loadEnv` | 100.0% |

Script output run locally against PR head `0ae19a2`:
```
=== Delta Coverage Check (threshold: 90.0%) ===

Changed source files:
  internal/anonymizer/streaming_provider.go
  internal/config/config.go

Checked 13 functions in 2 changed files.
SUCCESS: All functions in changed files meet 90.0% coverage threshold.
```

13 functions checked, 0 below threshold, minimum observed = 100.0%.

## §6 Test Inventory — baseline vs head

Per-package counts from `go test -count=1 -v ./<pkg>/` run in isolation (`-v` so subtests emit `--- PASS:` lines). `top` = top-level test functions; `sub` = `t.Run()` subtests.

| Package | Baseline (b9eff1a) top PASS / FAIL | Head (0ae19a2) top PASS / FAIL | Baseline sub PASS / FAIL | Head sub PASS / FAIL | Delta |
|---|---:|---:|---:|---:|---:|
| `cmd/proxy` | 4 / 0 | 4 / 0 | 0 / 0 | 0 / 0 | — |
| `internal/anonymizer` | 200 / 0 | **202 / 0** | 177 / 0 | **183 / 0** | +2 top, +6 sub |
| `internal/anonymizer/packs` | 71 / 0 | 71 / 0 | 106 / 0 | 106 / 0 | — |
| `internal/config` | 33 / 0 | **34 / 0** | 0 / 0 | 0 / 0 | +1 top |
| `internal/domainmatch` | 5 / 0 | 5 / 0 | 39 / 0 | 39 / 0 | — |
| `internal/logger` | 11 / 0 | 11 / 0 | 4 / 0 | 4 / 0 | — |
| `internal/management` | 38 / 0 | 38 / 0 | 14 / 0 | 14 / 0 | — |
| `internal/metrics` | 17 / 0 | 17 / 0 | 0 / 0 | 0 / 0 | — |
| `internal/mitm` | 30 / 0 | 30 / 0 | 0 / 0 | 0 / 0 | — |
| `internal/proxy` | 59 / 0 | 59 / 0 | 44 / 0 | 44 / 0 | — |
| **TOTAL** | **468 / 0** | **471 / 0** | **384 / 0** | **390 / 0** | **+3 top, +6 sub** |

Delta accounted for by the three new test functions:
- `internal/config` (+1 top): `TestCloudflareGatewayDomainRegistered`
- `internal/anonymizer` (+2 top, +6 sub): `TestCloudflarePassthroughDeanonymize` (1 top + 3 sub) + `TestCloudflareNonStreamingAnonymize` (1 top) + 3 new subtests appended to existing `TestProviderForDomain` (`gateway.ai.cloudflare.com`, uppercase, trailing-dot).

No existing tests changed PASS/FAIL state. Zero baseline failures, zero head failures across all 10 packages.

## Test Plan
- `TestCloudflareGatewayDomainRegistered` — verifies `gateway.ai.cloudflare.com` appears in default `AIAPIDomains`
- `TestProviderForDomain/gateway.ai.cloudflare.com` (+ uppercase and trailing-dot variants) — verifies domain routes to `ProviderPassthrough` including RFC 1035 case folding and trailing-dot canonical form
- `TestCloudflarePassthroughDeanonymize` — token replacement across OpenAI, Anthropic, and plain-text SSE formats through the same domain
- `TestCloudflareNonStreamingAnonymize` — request body anonymization + deanonymization round-trip

## Test Method Notes (docs/test-plans/ai-proxy-test-method.md)
- Read in full. §5 Known Issues: none touch domain routing or passthrough streaming, so none are relevant to this change.
- §6 Test Inventory: see baseline-vs-head table above.
