### PR TITLE
chore(cmd/proxy): decompose main() for testability + close delta-coverage gap

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -23,10 +23,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -41,62 +39,28 @@ import (
 func main() {
 	cfg := config.Load()
 
-	// Startup guard: zero enabled packs is a fatal misconfiguration.
 	if len(cfg.EnabledPacks) == 0 {
 		log.Fatalf("[PROXY] Fatal: no PII detection packs enabled. Configure enabledPacks in proxy-config.json or set ENABLED_PACKS env var.")
 	}
 
 	printBanner(cfg)
 
-	// Build the management domain registry so both servers share the same state.
-	// Runtime domain changes are persisted to ai-domains.json and restored on restart.
 	registry := management.NewDomainRegistry(cfg, "ai-domains.json")
-
-	// Shared metrics collector — passed to both servers so counters are unified.
 	m := metrics.New()
 
-	// Start management API in background.
-	// Fatal is intentional: the proxy should not run without its control plane.
-	mgmt := management.New(cfg, registry, m)
-	go func() {
-		if err := mgmt.ListenAndServe(); err != nil {
-			log.Fatalf("[MANAGEMENT] Fatal: %v", err)
-		}
-	}()
+	_ = startManagementAPI(cfg, registry, m)
 
-	// Start proxy server
 	proxyServer := proxy.New(cfg, registry, m)
-	defer func() {
-		if err := proxyServer.Close(); err != nil {
-			log.Printf("[PROXY] Cache close error: %v", err)
-		}
-	}()
+	defer closeProxyServer(proxyServer)
 
-	addr := fmt.Sprintf("%s:%d", cfg.BindAddress, cfg.ProxyPort)
-	log.Printf("[PROXY] Listening on %s", addr)
+	srv := proxyHTTPServer(cfg, proxyServer)
+	log.Printf("[PROXY] Listening on %s", srv.Addr)
 
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           proxyServer,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	// Graceful shutdown on SIGINT / SIGTERM
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-quit
-		log.Printf("[PROXY] Shutting down…")
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if err := srv.Shutdown(ctx); err != nil {
-			log.Printf("[PROXY] Shutdown error: %v", err)
-		}
-	}()
+	go installShutdownHandler(quit, srv, 15*time.Second)
 
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("[PROXY] Fatal: %v", err)
-	}
+	runHTTPServer(srv)
 }
 
 func printBanner(cfg *config.Config) {

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -101,7 +101,7 @@ func TestMain_HelperProcess_Lifecycle(t *testing.T) {
 	proxyPort := freePort(t)
 	mgmtPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0])
+	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -153,10 +153,14 @@ func TestMain_HelperProcess_ProxyPortConflict_Fatal(t *testing.T) {
 		t.Fatalf("parent listen: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
-	proxyPort := ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener address %T is not *net.TCPAddr", ln.Addr())
+	}
+	proxyPort := addr.Port
 	mgmtPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0])
+	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -184,10 +188,14 @@ func TestMain_HelperProcess_MgmtPortConflict_Fatal(t *testing.T) {
 		t.Fatalf("parent listen: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
-	mgmtPort := ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener address %T is not *net.TCPAddr", ln.Addr())
+	}
+	mgmtPort := addr.Port
 	proxyPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0])
+	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -212,11 +220,11 @@ func TestMain_HelperProcess_MgmtPortConflict_Fatal(t *testing.T) {
 func TestMain_HelperProcess_ZeroPacks_Fatal(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "proxy-config.json")
-	if err := os.WriteFile(cfgPath, []byte(`{"enabledPacks":[]}`), 0o644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte(`{"enabledPacks":[]}`), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(os.Args[0])
+	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -94,6 +94,20 @@ func TestPrintBanner_NoProxy_ShowsDirect(t *testing.T) {
 	}
 }
 
+// TestPrintBanner_ZeroValueConfig_DoesNotPanic asserts that printBanner
+// survives a zero-value *config.Config — a regression like a nil-map deref
+// or missing-field panic on uninitialised input would be caught here.
+// Inherited from the original TestMain_Smoke, kept as its own test so the
+// guarantee survives the helper-process TestMain rewrite.
+func TestPrintBanner_ZeroValueConfig_DoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("printBanner panicked on zero-value config: %v", r)
+		}
+	}()
+	_ = captureStdout(t, func() { printBanner(&config.Config{}) })
+}
+
 // TestMain_HelperProcess_Lifecycle re-execs this test binary as the proxy
 // daemon, waits for it to bind its listener, sends SIGTERM, and verifies a
 // clean exit. Exercises main()'s full startup-and-shutdown lifecycle.

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -101,7 +101,7 @@ func TestMain_HelperProcess_Lifecycle(t *testing.T) {
 	proxyPort := freePort(t)
 	mgmtPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -148,10 +148,7 @@ func TestMain_HelperProcess_Lifecycle(t *testing.T) {
 // the subprocess's srv.ListenAndServe() fails, exercising runHTTPServer's
 // log.Fatalf branch.
 func TestMain_HelperProcess_ProxyPortConflict_Fatal(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("parent listen: %v", err)
-	}
+	ln := listenLocal(t)
 	defer func() { _ = ln.Close() }()
 	addr, ok := ln.Addr().(*net.TCPAddr)
 	if !ok {
@@ -160,7 +157,7 @@ func TestMain_HelperProcess_ProxyPortConflict_Fatal(t *testing.T) {
 	proxyPort := addr.Port
 	mgmtPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -183,10 +180,7 @@ func TestMain_HelperProcess_ProxyPortConflict_Fatal(t *testing.T) {
 // so the subprocess's mgmt.ListenAndServe() fails, exercising runManagementAPI's
 // log.Fatalf branch.
 func TestMain_HelperProcess_MgmtPortConflict_Fatal(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("parent listen: %v", err)
-	}
+	ln := listenLocal(t)
 	defer func() { _ = ln.Close() }()
 	addr, ok := ln.Addr().(*net.TCPAddr)
 	if !ok {
@@ -195,7 +189,7 @@ func TestMain_HelperProcess_MgmtPortConflict_Fatal(t *testing.T) {
 	mgmtPort := addr.Port
 	proxyPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -224,7 +218,7 @@ func TestMain_HelperProcess_ZeroPacks_Fatal(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(os.Args[0]) // #nosec G204 -- helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1,14 +1,32 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"ai-anonymizing-proxy/internal/config"
 )
+
+// TestMain dispatches to main() when GO_WANT_HELPER_PROCESS=1, allowing
+// helper-process tests to re-exec this test binary as the production binary.
+// Pattern copied from stdlib os/exec internal tests.
+func TestMain(m *testing.M) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
+		main()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 // captureStdout redirects os.Stdout to a pipe for the duration of fn,
 // then returns everything written to it.
@@ -76,21 +94,167 @@ func TestPrintBanner_NoProxy_ShowsDirect(t *testing.T) {
 	}
 }
 
-// TestMain_Smoke verifies the package compiles and the binary entry point exists.
-// The actual main() starts network listeners so it cannot be called in tests.
-func TestMain_Smoke(t *testing.T) {
-	// Verify printBanner doesn't panic with zero-value config
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("printBanner panicked: %v", r)
-			}
-		}()
-		captureStdout(t, func() { printBanner(&config.Config{}) })
-	}()
+// TestMain_HelperProcess_Lifecycle re-execs this test binary as the proxy
+// daemon, waits for it to bind its listener, sends SIGTERM, and verifies a
+// clean exit. Exercises main()'s full startup-and-shutdown lifecycle.
+func TestMain_HelperProcess_Lifecycle(t *testing.T) {
+	proxyPort := freePort(t)
+	mgmtPort := freePort(t)
 
-	// Self-referential sanity: package name is main
-	if fmt.Sprintf("%T", main) != "func()" {
-		t.Error("expected main to be func()")
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"BIND_ADDRESS=127.0.0.1",
+		fmt.Sprintf("PROXY_PORT=%d", proxyPort),
+		fmt.Sprintf("MANAGEMENT_PORT=%d", mgmtPort),
+		"ENABLED_PACKS=SECRETS,GLOBAL",
+		"USE_AI_DETECTION=false",
+	)
+	cmd.Dir = t.TempDir()
+	stderr := &syncBuffer{}
+	cmd.Stderr = stderr
+	cmd.Stdout = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
 	}
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	waitForLog(t, stderr, "[PROXY] Listening on", 10*time.Second)
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("process exited with error: %v\n%s", err, stderr.String())
+		}
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("process did not exit within 10s of SIGTERM\n%s", stderr.String())
+	}
+}
+
+// TestMain_HelperProcess_ProxyPortConflict_Fatal pre-binds the proxy port so
+// the subprocess's srv.ListenAndServe() fails, exercising runHTTPServer's
+// log.Fatalf branch.
+func TestMain_HelperProcess_ProxyPortConflict_Fatal(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("parent listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	proxyPort := ln.Addr().(*net.TCPAddr).Port
+	mgmtPort := freePort(t)
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"BIND_ADDRESS=127.0.0.1",
+		fmt.Sprintf("PROXY_PORT=%d", proxyPort),
+		fmt.Sprintf("MANAGEMENT_PORT=%d", mgmtPort),
+		"ENABLED_PACKS=SECRETS,GLOBAL",
+		"USE_AI_DETECTION=false",
+	)
+	cmd.Dir = t.TempDir()
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit on proxy port conflict, got success\n%s", out)
+	}
+	if !strings.Contains(string(out), "[PROXY] Fatal") {
+		t.Errorf("expected '[PROXY] Fatal' in output, got:\n%s", out)
+	}
+}
+
+// TestMain_HelperProcess_MgmtPortConflict_Fatal pre-binds the management port
+// so the subprocess's mgmt.ListenAndServe() fails, exercising runManagementAPI's
+// log.Fatalf branch.
+func TestMain_HelperProcess_MgmtPortConflict_Fatal(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("parent listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	mgmtPort := ln.Addr().(*net.TCPAddr).Port
+	proxyPort := freePort(t)
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"BIND_ADDRESS=127.0.0.1",
+		fmt.Sprintf("PROXY_PORT=%d", proxyPort),
+		fmt.Sprintf("MANAGEMENT_PORT=%d", mgmtPort),
+		"ENABLED_PACKS=SECRETS,GLOBAL",
+		"USE_AI_DETECTION=false",
+	)
+	cmd.Dir = t.TempDir()
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit on mgmt port conflict, got success\n%s", out)
+	}
+	if !strings.Contains(string(out), "[MANAGEMENT] Fatal") {
+		t.Errorf("expected '[MANAGEMENT] Fatal' in output, got:\n%s", out)
+	}
+}
+
+// TestMain_HelperProcess_ZeroPacks_Fatal verifies that a config with no packs
+// enabled triggers the startup guard's log.Fatalf (non-zero exit). Covers that
+// branch of main() which is otherwise unreachable from the lifecycle test.
+func TestMain_HelperProcess_ZeroPacks_Fatal(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "proxy-config.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"enabledPacks":[]}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit on zero-packs guard, got success\n%s", out)
+	}
+	if !strings.Contains(string(out), "no PII detection packs enabled") {
+		t.Errorf("expected guard message in output, got:\n%s", out)
+	}
+}
+
+// syncBuffer is a goroutine-safe wrapper around bytes.Buffer for use as
+// cmd.Stderr while a poller in the parent reads it concurrently.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func waitForLog(t *testing.T, buf *syncBuffer, substr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), substr) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("did not see %q in log within %v\n%s", substr, timeout, buf.String())
 }

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -101,7 +101,7 @@ func TestMain_HelperProcess_Lifecycle(t *testing.T) {
 	proxyPort := freePort(t)
 	mgmtPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.CommandContext(t.Context(), os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -157,7 +157,7 @@ func TestMain_HelperProcess_ProxyPortConflict_Fatal(t *testing.T) {
 	proxyPort := addr.Port
 	mgmtPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.CommandContext(t.Context(), os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -189,7 +189,7 @@ func TestMain_HelperProcess_MgmtPortConflict_Fatal(t *testing.T) {
 	mgmtPort := addr.Port
 	proxyPort := freePort(t)
 
-	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.CommandContext(t.Context(), os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_HELPER_PROCESS=1",
 		"BIND_ADDRESS=127.0.0.1",
@@ -218,7 +218,7 @@ func TestMain_HelperProcess_ZeroPacks_Fatal(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cmd := exec.Command(os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
+	cmd := exec.CommandContext(t.Context(), os.Args[0]) //nolint:gosec // G204: helper-process pattern: os.Args[0] is the test binary itself, not external input
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()

--- a/cmd/proxy/shutdown.go
+++ b/cmd/proxy/shutdown.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// installShutdownHandler blocks on quit, then calls srv.Shutdown with the given
+// timeout. Intended to run in a goroutine spawned by main().
+func installShutdownHandler(quit <-chan os.Signal, srv *http.Server, timeout time.Duration) {
+	<-quit
+	log.Printf("[PROXY] Shutting down…")
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("[PROXY] Shutdown error: %v", err)
+	}
+}

--- a/cmd/proxy/shutdown_test.go
+++ b/cmd/proxy/shutdown_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestInstallShutdownHandler_GracefulOnSignal(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler:           http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+		ReadHeaderTimeout: 1 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+
+	quit := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	go func() {
+		installShutdownHandler(quit, srv, 2*time.Second)
+		close(done)
+	}()
+
+	quit <- syscall.SIGTERM
+	select {
+	case <-done:
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+ln.Addr().String()+"/", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			t.Error("server still accepting requests after Shutdown")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("installShutdownHandler did not return within 3s of SIGTERM")
+	}
+}
+
+func TestInstallShutdownHandler_TimeoutPath(t *testing.T) {
+	hung := make(chan struct{})
+	defer close(hung)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-hung
+		}),
+		ReadHeaderTimeout: 1 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+
+	// Kick off a long-running request, then shutdown. Use a short client
+	// timeout so this goroutine doesn't outlive the test on the timeout path.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+ln.Addr().String()+"/", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	quit := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		installShutdownHandler(quit, srv, 200*time.Millisecond)
+		close(done)
+	}()
+	quit <- syscall.SIGTERM
+
+	select {
+	case <-done:
+		elapsed := time.Since(start)
+		if elapsed > 1*time.Second {
+			t.Errorf("shutdown took %v, expected ~200ms (timeout path)", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("installShutdownHandler did not return after Shutdown timeout")
+	}
+}

--- a/cmd/proxy/shutdown_test.go
+++ b/cmd/proxy/shutdown_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"os"
 	"syscall"
@@ -11,12 +10,9 @@ import (
 )
 
 func TestInstallShutdownHandler_GracefulOnSignal(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	ln := listenLocal(t)
 	srv := &http.Server{
-		Handler:           http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+		Handler:           http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}),
 		ReadHeaderTimeout: 1 * time.Second,
 	}
 	go func() { _ = srv.Serve(ln) }()
@@ -48,12 +44,9 @@ func TestInstallShutdownHandler_TimeoutPath(t *testing.T) {
 	hung := make(chan struct{})
 	defer close(hung)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	ln := listenLocal(t)
 	srv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			<-hung
 		}),
 		ReadHeaderTimeout: 1 * time.Second,

--- a/cmd/proxy/shutdown_test.go
+++ b/cmd/proxy/shutdown_test.go
@@ -34,7 +34,7 @@ func TestInstallShutdownHandler_GracefulOnSignal(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+ln.Addr().String()+"/", nil)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req) // #nosec G107,G704 -- in-test URL from a net.Listener owned by this test
 		if err == nil {
 			_ = resp.Body.Close()
 			t.Error("server still accepting requests after Shutdown")
@@ -66,7 +66,7 @@ func TestInstallShutdownHandler_TimeoutPath(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+ln.Addr().String()+"/", nil)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req) // #nosec G107,G704 -- in-test URL from a net.Listener owned by this test
 		if err == nil {
 			_ = resp.Body.Close()
 		}

--- a/cmd/proxy/startup.go
+++ b/cmd/proxy/startup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -47,15 +48,10 @@ func runHTTPServer(srv *http.Server) {
 	}
 }
 
-// closer is the interface implemented by anything with Close() error.
-// Exists so closeProxyServer can be unit-tested with a fake.
-type closer interface {
-	Close() error
-}
-
 // closeProxyServer invokes Close on the proxy server and logs any error.
-// Intended for use as a deferred call in main().
-func closeProxyServer(s closer) {
+// Intended for use as a deferred call in main(). Takes an io.Closer rather
+// than *proxy.Server so the error-log branch can be exercised with a fake.
+func closeProxyServer(s io.Closer) {
 	if err := s.Close(); err != nil {
 		log.Printf("[PROXY] Cache close error: %v", err)
 	}

--- a/cmd/proxy/startup.go
+++ b/cmd/proxy/startup.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"ai-anonymizing-proxy/internal/config"
+	"ai-anonymizing-proxy/internal/management"
+	"ai-anonymizing-proxy/internal/metrics"
+)
+
+// proxyHTTPServer builds the *http.Server wrapping the MITM proxy handler.
+// Caller is responsible for invoking ListenAndServe / Serve.
+func proxyHTTPServer(cfg *config.Config, h http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", cfg.BindAddress, cfg.ProxyPort),
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}
+
+// startManagementAPI constructs the management server and launches its
+// listener in a background goroutine. Returns the server so callers can hold
+// a reference for shutdown.
+func startManagementAPI(cfg *config.Config, registry *management.DomainRegistry, m *metrics.Metrics) *management.Server {
+	mgmt := management.New(cfg, registry, m)
+	go runManagementAPI(mgmt)
+	return mgmt
+}
+
+// runManagementAPI blocks on mgmt.ListenAndServe and calls log.Fatalf if it
+// returns an error. Intended to run as a goroutine — the proxy must not stay
+// alive without its control plane.
+func runManagementAPI(mgmt *management.Server) {
+	if err := mgmt.ListenAndServe(); err != nil {
+		log.Fatalf("[MANAGEMENT] Fatal: %v", err)
+	}
+}
+
+// runHTTPServer blocks on srv.ListenAndServe and calls log.Fatalf if it returns
+// a non-shutdown error.
+func runHTTPServer(srv *http.Server) {
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("[PROXY] Fatal: %v", err)
+	}
+}
+
+// closer is the interface implemented by anything with Close() error.
+// Exists so closeProxyServer can be unit-tested with a fake.
+type closer interface {
+	Close() error
+}
+
+// closeProxyServer invokes Close on the proxy server and logs any error.
+// Intended for use as a deferred call in main().
+func closeProxyServer(s closer) {
+	if err := s.Close(); err != nil {
+		log.Printf("[PROXY] Cache close error: %v", err)
+	}
+}

--- a/cmd/proxy/startup_test.go
+++ b/cmd/proxy/startup_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"ai-anonymizing-proxy/internal/config"
+	"ai-anonymizing-proxy/internal/management"
+	"ai-anonymizing-proxy/internal/metrics"
+)
+
+type fakeCloser struct{ err error }
+
+func (f fakeCloser) Close() error { return f.err }
+
+func TestCloseProxyServer_NoError(t *testing.T) {
+	closeProxyServer(fakeCloser{nil})
+}
+
+func TestCloseProxyServer_LogsError(t *testing.T) {
+	closeProxyServer(fakeCloser{errors.New("boom")})
+}
+
+func TestProxyHTTPServer_WiringFromConfig(t *testing.T) {
+	cfg := &config.Config{BindAddress: "127.0.0.1", ProxyPort: 18080}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	srv := proxyHTTPServer(cfg, handler)
+
+	if srv.Addr != "127.0.0.1:18080" {
+		t.Errorf("Addr = %q, want 127.0.0.1:18080", srv.Addr)
+	}
+	if srv.Handler == nil {
+		t.Error("Handler is nil")
+	}
+	if srv.ReadHeaderTimeout != 10*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want 10s", srv.ReadHeaderTimeout)
+	}
+}
+
+func TestStartManagementAPI_ServesRequests(t *testing.T) {
+	port := freePort(t)
+	cfg := &config.Config{
+		BindAddress:    "127.0.0.1",
+		ManagementPort: port,
+		EnabledPacks:   []string{"SECRETS", "GLOBAL"},
+	}
+	registry := management.NewDomainRegistry(cfg, "")
+	m := metrics.New()
+
+	got := startManagementAPI(cfg, registry, m)
+	if got == nil {
+		t.Fatal("startManagementAPI returned nil server")
+	}
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/status", port)
+	resp, err := pollUntilUp(url, 2*time.Second)
+	if err != nil {
+		t.Fatalf("mgmt API not reachable: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 500 {
+		t.Errorf("mgmt API status = %d", resp.StatusCode)
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+func pollUntilUp(url string, timeout time.Duration) (*http.Response, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	return nil, lastErr
+}

--- a/cmd/proxy/startup_test.go
+++ b/cmd/proxy/startup_test.go
@@ -74,10 +74,7 @@ func TestStartManagementAPI_ServesRequests(t *testing.T) {
 
 func freePort(t *testing.T) int {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("net.Listen: %v", err)
-	}
+	l := listenLocal(t)
 	addr, ok := l.Addr().(*net.TCPAddr)
 	if !ok {
 		_ = l.Close()
@@ -85,6 +82,20 @@ func freePort(t *testing.T) int {
 	}
 	_ = l.Close()
 	return addr.Port
+}
+
+// listenLocal binds an unused 127.0.0.1 port using a context-aware ListenConfig
+// (the form noctx accepts). Caller is responsible for Close.
+func listenLocal(t *testing.T) net.Listener {
+	t.Helper()
+	var lc net.ListenConfig
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln
 }
 
 func pollUntilUp(url string, timeout time.Duration) (*http.Response, error) {

--- a/cmd/proxy/startup_test.go
+++ b/cmd/proxy/startup_test.go
@@ -19,17 +19,17 @@ type fakeCloser struct{ err error }
 
 func (f fakeCloser) Close() error { return f.err }
 
-func TestCloseProxyServer_NoError(t *testing.T) {
+func TestCloseProxyServer_NoError(_ *testing.T) {
 	closeProxyServer(fakeCloser{nil})
 }
 
-func TestCloseProxyServer_LogsError(t *testing.T) {
+func TestCloseProxyServer_LogsError(_ *testing.T) {
 	closeProxyServer(fakeCloser{errors.New("boom")})
 }
 
 func TestProxyHTTPServer_WiringFromConfig(t *testing.T) {
 	cfg := &config.Config{BindAddress: "127.0.0.1", ProxyPort: 18080}
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
 	srv := proxyHTTPServer(cfg, handler)
 

--- a/cmd/proxy/startup_test.go
+++ b/cmd/proxy/startup_test.go
@@ -78,9 +78,13 @@ func freePort(t *testing.T) int {
 	if err != nil {
 		t.Fatalf("net.Listen: %v", err)
 	}
-	port := l.Addr().(*net.TCPAddr).Port
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = l.Close()
+		t.Fatalf("listener address %T is not *net.TCPAddr", l.Addr())
+	}
 	_ = l.Close()
-	return port
+	return addr.Port
 }
 
 func pollUntilUp(url string, timeout time.Duration) (*http.Response, error) {
@@ -93,7 +97,7 @@ func pollUntilUp(url string, timeout time.Duration) (*http.Response, error) {
 			cancel()
 			return nil, err
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req) // #nosec G107,G704 -- localhost test URL from a net.Listener bound by the parent test
 		cancel()
 		if err == nil {
 			return resp, nil

--- a/cmd/proxy/startup_test.go
+++ b/cmd/proxy/startup_test.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,12 +22,33 @@ type fakeCloser struct{ err error }
 
 func (f fakeCloser) Close() error { return f.err }
 
-func TestCloseProxyServer_NoError(_ *testing.T) {
-	closeProxyServer(fakeCloser{nil})
+// captureLog redirects the default logger's output to a buffer for the
+// duration of fn. Restores the previous destination on return.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	prev := log.Writer()
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+	defer log.SetOutput(prev)
+	fn()
+	return buf.String()
 }
 
-func TestCloseProxyServer_LogsError(_ *testing.T) {
-	closeProxyServer(fakeCloser{errors.New("boom")})
+func TestCloseProxyServer_NoError_DoesNotLog(t *testing.T) {
+	out := captureLog(t, func() { closeProxyServer(fakeCloser{nil}) })
+	if out != "" {
+		t.Errorf("expected no log output on success, got: %q", out)
+	}
+}
+
+func TestCloseProxyServer_LogsError(t *testing.T) {
+	out := captureLog(t, func() { closeProxyServer(fakeCloser{errors.New("boom")}) })
+	if !strings.Contains(out, "[PROXY] Cache close error") {
+		t.Errorf("expected '[PROXY] Cache close error' in log, got: %q", out)
+	}
+	if !strings.Contains(out, "boom") {
+		t.Errorf("expected underlying error 'boom' in log, got: %q", out)
+	}
 }
 
 func TestProxyHTTPServer_WiringFromConfig(t *testing.T) {
@@ -72,6 +96,12 @@ func TestStartManagementAPI_ServesRequests(t *testing.T) {
 	}
 }
 
+// freePort returns a 127.0.0.1 TCP port that is unused at the moment of the
+// call. There is an inherent race: the OS may hand the same port to another
+// process between this call and the caller's re-bind. We accept that race —
+// no clean alternative exists when the consumer is a subprocess that must
+// open its own listener — and rely on the helper-process tests' own
+// log-based readiness probe to surface the rare collision.
 func freePort(t *testing.T) int {
 	t.Helper()
 	l := listenLocal(t)


### PR DESCRIPTION
## Summary
Decomposes `cmd/proxy/main.go` `func main()` into separately-testable startup
helpers and adds a helper-process `TestMain` that exercises `main()` end-to-end.
Closes the structural delta-coverage gap surfaced by #118 — every function in
`cmd/proxy/` now meets the 95% per-function gate, so future PRs touching this
file (including #120's `--generate-ca` flag addition) land without false
coverage failures.

## Motivation
- #118 closed a silent-skip bug in `.github/scripts/delta-coverage.sh`. Before
  that fix, PRs touching `cmd/proxy/main.go` quietly bypassed the per-function
  gate.
- #120 is the first PR to actually hit the now-loud gate. `main()` has always
  been 0% covered (network setup + signal handling), so any change to the file
  fails 95%.
- Rather than per-PR workarounds, this PR fixes the root cause on `main`:
  refactor `main()` into testable helpers + helper-process tests that exercise
  the real binary.

## What changed
- New `cmd/proxy/startup.go` — `proxyHTTPServer`, `startManagementAPI`,
  `runManagementAPI`, `runHTTPServer`, `closeProxyServer` (extracted from
  `main()`). `closeProxyServer` takes `io.Closer` so the error-log branch is
  exercisable with a fake.
- New `cmd/proxy/shutdown.go` — `installShutdownHandler` (extracted from
  `main()`).
- New unit tests in `cmd/proxy/startup_test.go` and `cmd/proxy/shutdown_test.go`
  covering each helper at 100%. `TestCloseProxyServer_*` capture the default
  logger's output and assert the error message is/isn't emitted, not just that
  both branches execute.
- `cmd/proxy/main_test.go` — `TestMain` dispatcher + four helper-process tests
  (lifecycle, zero-packs guard, proxy-port conflict, mgmt-port conflict) using
  the canonical Go helper-process pattern (`GO_WANT_HELPER_PROCESS=1` + re-exec
  of `os.Args[0]`). `TestPrintBanner_ZeroValueConfig_DoesNotPanic` preserves
  the zero-value-config guarantee previously owned by `TestMain_Smoke`.
- `cmd/proxy/main.go` `func main()` reduced to orchestration; no behaviour
  change.

## Per-function coverage (`go tool cover -func`)

```
cmd/proxy/main.go:39:     main                    100.0%
cmd/proxy/main.go:66:     printBanner             100.0%
cmd/proxy/shutdown.go:13: installShutdownHandler  100.0%
cmd/proxy/startup.go:17:  proxyHTTPServer         100.0%
cmd/proxy/startup.go:28:  startManagementAPI      100.0%
cmd/proxy/startup.go:37:  runManagementAPI        100.0%
cmd/proxy/startup.go:45:  runHTTPServer           100.0%
cmd/proxy/startup.go:54:  closeProxyServer        100.0%
total:                                            100.0%
```

Local `delta-coverage.sh coverage.out 95.0 origin/main` exits 0:

```
=== Delta Coverage Check (threshold: 95.0%) ===

Changed source files:
  cmd/proxy/main.go
  cmd/proxy/shutdown.go
  cmd/proxy/startup.go

Checked 8 functions in 3 changed files.
SUCCESS: All functions in changed files meet 95.0% coverage threshold.
```

## Quality gates
- [x] `go test -race ./...` green (all packages) — see `TestTokenFormatNonRetriggering` evidence below
- [x] `bash .github/scripts/delta-coverage.sh coverage.out 95.0 origin/main`
      exits 0 with `SUCCESS`
- [x] Coverage minimums hold: `internal/anonymizer` 95.6%, `internal/config`
      100%, `internal/anonymizer/packs` 97.6%; overall well above 85%
- [x] Lifecycle helper-process test stable across 5 consecutive local runs
- [x] No `t.Skip()`, no `// coverage-ignore`, no hardcoded test-satisfying
      values. Four `//nolint:gosec` and two `// #nosec` directives carry
      substantive reason comments per the existing repo convention.
- [ ] `make lint` / `make check` — `golangci-lint` in the local sandbox is
      built with go1.25 and refuses go1.26.3 modules (same failure on a clean
      `main` checkout). CI runs all four sub-gates against a fresher toolchain.

## Gate #2 — `TestTokenFormatNonRetriggering` for every PII type

Both variants live in `internal/anonymizer/anonymizer_test.go` and ran green at
head `c69911f`:

```
=== RUN   TestTokenFormatNonRetriggering
[ANONYMIZER] loaded 41 patterns from 7 enabled packs: [SECRETS GLOBAL DE FR NL FINANCE_EU HEALTHCARE]
--- PASS: TestTokenFormatNonRetriggering (0.04s)
=== RUN   TestTokenFormatNonRetriggeringAllPacks
[ANONYMIZER] loaded 47 patterns from 8 enabled packs: [SECRETS GLOBAL DE FR US NL FINANCE_EU HEALTHCARE]
--- PASS: TestTokenFormatNonRetriggeringAllPacks (0.04s)
```

Each variant iterates over a static list of `PIIType` values and, for each,
asserts the generated `[PII_*_<16hex>]` token does not match any loaded pack
pattern. The PII types covered:

| Pack | PII types asserted by the test |
|---|---|
| Generic / built-in | `PIIEmail`, `PIIPhone`, `PIISSN`, `PIICreditCard`, `PIIIPAddress`, `PIIAPIKey`, `PIIName`, `PIIAddress`, `PIIMedical`, `PIISalary`, `PIICompany`, `PIIJobTitle` |
| DE | `PIISteuerID`, `PIISVNR`, `PIIKFZ` |
| SECRETS | `PIISSHKey`, `PIIJWT`, `PIIBearer`, `PIIDBConn`, `PIIAWSKey`, `PIIGHToken` |
| FR | `PIINIR`, `PIISIRET`, `PIISIREN` |
| NL | `PIIBSN`, `PIIKVK` |
| FINANCE_EU | `PIIIBAN`, `PIISWIFTBIC`, `PIIVATID` |
| HEALTHCARE | `PIIMRN`, `PIIICD10`, `PIIInsuranceID` |

That's 32 PII types in the default-packs variant. `TestTokenFormatNonRetriggeringAllPacks`
adds the US pack and drops the four AI-only types (`PIIMedical/Salary/Company/JobTitle`),
covering 28 types under the full pattern set (`PIIKFZ`/`PIIDBConn` are noted in
the test as known low-confidence retriggers against the broad US phone pattern
and routed through the AI gate — documented in the test, not silenced).

The two variants together cross every PII type declared in
`internal/anonymizer/anonymizer.go`. None of the changed files in this PR touch
the anonymizer, the pack files, or the PII type list, so no per-type evidence
shifted between baseline and head — but the gate is exercised end-to-end at
head as shown above.

## §6 Test Inventory — baseline vs head

Keyed by **pack** per `docs/test-plans/ai-proxy-test-method.md` §6.
Captured by running `go test -count=1 -json ./internal/anonymizer ./internal/anonymizer/packs`
on `origin/main` (`98511d7`) and on PR head (`c69911f`), then attributing
each top-level Test event to its pack via the file list in §6.

| Pack | Files (per §6) | Baseline PASS | Baseline FAIL | Head PASS | Head FAIL | Delta |
|---|---|---:|---:|---:|---:|---:|
| GLOBAL | `packs/global_test.go` | 6 | 0 | 6 | 0 | 0 |
| DE | `packs/de_test.go` | 5 | 0 | 5 | 0 | 0 |
| US | `packs/us_test.go` | 10 | 0 | 10 | 0 | 0 |
| FR | `packs/fr_test.go` | 9 | 0 | 9 | 0 | 0 |
| SECRETS | `packs/secrets_test.go` + `secrets_report_test.go` + `secrets_priority_report_test.go` | 31 | 0 | 31 | 0 | 0 |
| NL | `packs/nl_test.go` + `nl_report_test.go` | 6 | 0 | 6 | 0 | 0 |
| FINANCE_EU | `packs/finance_eu_test.go` + `finance_eu_report_test.go` | 7 | 0 | 7 | 0 | 0 |
| HEALTHCARE | `packs/healthcare_test.go` + `healthcare_report_test.go` | 6 | 0 | 6 | 0 | 0 |
| Cross-pack | all `*_report_test.go` | 9 | 0 | 9 | 0 | 0 |

Counts are top-level `func Test*` events from the JSON stream, filtered by the
test-name list extracted from each pack's `_test.go` file(s). The
`secrets_priority_report_test.go` file lives alongside `secrets_report_test.go`,
was added after §6 was written, and is included under SECRETS (its prefix
matches the SECRETS pack convention). The Cross-pack row overlaps with the
pack rows by design (it sums all `*_report_test.go` content, which the
relevant per-pack rows already include).

**Supplementary Go-package view** — `go test -count=1 -json ./...` gives
861 → 871 PASS / 0 → 0 FAIL across all 10 Go packages; the `cmd/proxy` row
went 4 → 14, every other row unchanged. The per-pack table above is the
gate-required view.

## §6 changed-files attribution
None of the changed files in this PR (`cmd/proxy/main.go`, `cmd/proxy/startup.go`,
`cmd/proxy/shutdown.go`, plus the corresponding `_test.go` files) live under
any pack's file list, so the identical per-pack counts are the expected
measured outcome, not a substitution for measurement.

## Test plan
- [x] `go test -race ./cmd/proxy/...` — all green including new
      helper-process tests
- [x] `go test -race -run '^TestTokenFormatNonRetriggering' ./internal/anonymizer/...` — both variants PASS at head
- [x] `go tool cover -func` — every function in `cmd/proxy/` at 100%
- [x] Local `delta-coverage.sh` simulation against `origin/main` — exits 0
- [x] Lifecycle test run 5x consecutively — 5/5 pass
- [x] CI green (Lint, Test, Security Scan, Benchmark, CodeQL × 2, Build) at
      `c69911f`

## Out of scope
- Any changes under `packaging/linux/` — Fedora `ca-certificates` and openSUSE
  trust-store path belong to #120 follow-up commits after rebase.
- Any changes to `internal/*`, `.github/workflows/`, or
  `.github/scripts/delta-coverage.sh`.
- Adding a second binary or the `--generate-ca` flag (#120's territory).