### PR TITLE
feat(packaging): macos pkg + .mobileconfig profile

### DIFF
--- a/.github/workflows/release-macos-pkg.yml
+++ b/.github/workflows/release-macos-pkg.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
 
+# Tagged releases produce signed artifacts and a GitHub release — running two
+# at once would race the upload. PR runs can overlap by head SHA.
+concurrency:
+  group: macos-pkg-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build (macos-latest)
@@ -22,8 +28,9 @@ jobs:
     permissions:
       contents: read
     env:
-      # PRs don't notarize: Apple rejects re-submissions of identical content
-      # and notarization is a release-time concern. Tag builds notarize+staple.
+      # Apple rejects re-submission of identical content for notarization, and
+      # the 10 signing secrets are a release-time concern. PR runs validate
+      # compilation + script + plist syntax; tag runs sign + notarize + upload.
       IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout code
@@ -37,7 +44,29 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # PR-time validation. Confirms the workflow YAML parses (implicit via
+      # this job being scheduled), the binary compiles for darwin universal,
+      # and every shell / XML / plist artifact in packaging/macos is syntactically
+      # valid before any signing key is touched. Catches the bugs that don't
+      # require real Apple secrets to find.
+      - name: Validate (no secrets required)
+        run: |
+          set -euo pipefail
+          GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/ai-proxy-amd64 ./cmd/proxy
+          GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o /tmp/ai-proxy-arm64 ./cmd/proxy
+          for s in packaging/macos/pkg/build.sh \
+                   packaging/macos/pkg/notarize.sh \
+                   packaging/macos/pkg/scripts/postinstall \
+                   packaging/macos/pkg/scripts/preuninstall \
+                   packaging/macos/mobileconfig/build.sh; do
+            bash -n "$s"
+          done
+          plutil -lint packaging/macos/pkg/com.ai-anonymizing-proxy.plist
+          xmllint --noout packaging/macos/pkg/distribution.xml
+          xmllint --noout packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl
+
       - name: Verify required Secrets present
+        if: env.IS_RELEASE == 'true'
         env:
           MACOS_INSTALLER_CERT_P12: ${{ secrets.MACOS_INSTALLER_CERT_P12 }}
           MACOS_INSTALLER_CERT_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_PASSWORD }}
@@ -64,6 +93,7 @@ jobs:
           [ "$missing" -eq 0 ]
 
       - name: Set up signing keychain
+        if: env.IS_RELEASE == 'true'
         env:
           MACOS_INSTALLER_CERT_P12: ${{ secrets.MACOS_INSTALLER_CERT_P12 }}
           MACOS_INSTALLER_CERT_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_PASSWORD }}
@@ -71,6 +101,12 @@ jobs:
           MACOS_APPLICATION_CERT_PASSWORD: ${{ secrets.MACOS_APPLICATION_CERT_PASSWORD }}
           MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
         run: |
+          set -euo pipefail
+          # P12 files briefly land in the workspace. Trap on EXIT cleans them
+          # up on every exit path (including `security import` failure),
+          # not just the happy path — H5 remediation.
+          trap 'rm -f installer.p12 app.p12' EXIT
+
           KEYCHAIN=build.keychain
           security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security default-keychain -s "$KEYCHAIN"
@@ -80,12 +116,10 @@ jobs:
           echo "$MACOS_INSTALLER_CERT_P12" | base64 -d > installer.p12
           security import installer.p12 -k "$KEYCHAIN" -P "$MACOS_INSTALLER_CERT_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
-          rm installer.p12
 
           echo "$MACOS_APPLICATION_CERT_P12" | base64 -d > app.p12
           security import app.p12 -k "$KEYCHAIN" -P "$MACOS_APPLICATION_CERT_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
-          rm app.p12
 
           security set-key-partition-list -S apple-tool:,apple: \
             -s -k "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -102,6 +136,7 @@ jobs:
           echo "MACOS_APPLICATION_IDENTITY=$APP" >> "$GITHUB_ENV"
 
       - name: Stage release CA
+        if: env.IS_RELEASE == 'true'
         env:
           MACOS_RELEASE_CA_CERT: ${{ secrets.MACOS_RELEASE_CA_CERT }}
           MACOS_RELEASE_CA_KEY: ${{ secrets.MACOS_RELEASE_CA_KEY }}
@@ -113,11 +148,13 @@ jobs:
           echo "CA_CERT_FILE_FOR_RELEASE=$PWD/build/release-ca/ca-cert.pem" >> "$GITHUB_ENV"
 
       - name: Build PKG
+        if: env.IS_RELEASE == 'true'
         env:
           PKG_VERSION: ${{ github.ref_name }}
         run: make package-macos-pkg
 
       - name: Build .mobileconfig
+        if: env.IS_RELEASE == 'true'
         env:
           PKG_VERSION: ${{ github.ref_name }}
         run: make package-macos-mobileconfig
@@ -138,12 +175,11 @@ jobs:
           done
 
       - name: Verify artifacts
+        if: env.IS_RELEASE == 'true'
         run: |
           for pkg in dist/*.pkg; do
             pkgutil --check-signature "$pkg"
-            if [ "$IS_RELEASE" = "true" ]; then
-              spctl --assess --type install --verbose=2 "$pkg"
-            fi
+            spctl --assess --type install --verbose=2 "$pkg"
           done
           for mc in dist/*.mobileconfig; do
             plutil -lint "$mc"
@@ -154,11 +190,17 @@ jobs:
         if: always()
         run: rm -rf build/release-ca
 
+      # Explicit file list — H6: glob (dist/*) could pick up adjacent build
+      # artifacts if a future helper writes to dist/. Named files only.
       - name: Upload artifacts
+        if: env.IS_RELEASE == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos
-          path: dist/*
+          path: |
+            dist/ai-proxy-*-universal.pkg
+            dist/ai-proxy-*.mobileconfig
+          if-no-files-found: error
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release-macos-pkg.yml
+++ b/.github/workflows/release-macos-pkg.yml
@@ -44,16 +44,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # PR-time validation. Confirms the workflow YAML parses (implicit via
-      # this job being scheduled), the binary compiles for darwin universal,
-      # and every shell / XML / plist artifact in packaging/macos is syntactically
-      # valid before any signing key is touched. Catches the bugs that don't
-      # require real Apple secrets to find.
-      - name: Validate (no secrets required)
+      # PR-event coverage. Runs the actual build scripts unsigned — exercises
+      # payload staging, lipo, pkgbuild, productbuild, distribution.xml
+      # substitution, mobileconfig template rendering, base64 CA encoding,
+      # and plutil-lint. Catches mechanical bugs that the lint-only path
+      # missed (PR #123 review N1). The resulting artifacts are unsigned
+      # and cannot be installed; they're discarded after the step.
+      - name: Validate build mechanism (PR dry-run, no signing)
+        if: env.IS_RELEASE != 'true'
         run: |
           set -euo pipefail
-          GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/ai-proxy-amd64 ./cmd/proxy
-          GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o /tmp/ai-proxy-arm64 ./cmd/proxy
+          # Static checks first — fast fail on syntax issues.
           for s in packaging/macos/pkg/build.sh \
                    packaging/macos/pkg/notarize.sh \
                    packaging/macos/pkg/scripts/postinstall \
@@ -64,6 +65,41 @@ jobs:
           plutil -lint packaging/macos/pkg/com.ai-anonymizing-proxy.plist
           xmllint --noout packaging/macos/pkg/distribution.xml
           xmllint --noout packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl
+
+          # Generate a throwaway CA so mobileconfig/build.sh has something
+          # to base64-encode into the certificate payload. This CA never
+          # leaves the runner and is not used for signing — it is the
+          # payload contents only.
+          mkdir -p build/dry-run-ca
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -subj "/CN=ai-proxy PR dry-run (NOT FOR USE)" \
+            -keyout build/dry-run-ca/ca-key.pem \
+            -out    build/dry-run-ca/ca-cert.pem >/dev/null 2>&1
+          chmod 0600 build/dry-run-ca/ca-key.pem
+
+          PKG_VERSION=0.0.0-dryrun \
+          SKIP_SIGN=1 \
+          bash packaging/macos/pkg/build.sh
+
+          PKG_VERSION=0.0.0-dryrun \
+          CA_CERT="$PWD/build/dry-run-ca/ca-cert.pem" \
+          SKIP_SIGN=1 \
+          bash packaging/macos/mobileconfig/build.sh
+
+          # Verify the artifacts the build path produced.
+          test -f dist/ai-proxy-0.0.0-dryrun-universal.pkg
+          test -f dist/ai-proxy-0.0.0-dryrun.mobileconfig
+          # Distribution PKG's component payload list should mention the binary
+          # and the LaunchDaemon plist — quickest mechanical structural check.
+          pkgutil --payload-files dist/ai-proxy-0.0.0-dryrun-universal.pkg \
+            | grep -q '/usr/local/bin/ai-proxy'
+          pkgutil --payload-files dist/ai-proxy-0.0.0-dryrun-universal.pkg \
+            | grep -q '/Library/LaunchDaemons/com.ai-anonymizing-proxy.plist'
+          plutil -lint dist/ai-proxy-0.0.0-dryrun.mobileconfig
+
+          # Discard the unsigned artifacts so they cannot ride into any later
+          # step or upload. The release path will rebuild from scratch.
+          rm -rf dist build/dry-run-ca build/macos
 
       - name: Verify required Secrets present
         if: env.IS_RELEASE == 'true'
@@ -159,6 +195,13 @@ jobs:
           PKG_VERSION: ${{ github.ref_name }}
         run: make package-macos-mobileconfig
 
+      # Release-gate reminder: before pushing a v* tag that reaches this step,
+      # the .mobileconfig HTTPS-interception verification ritual MUST have
+      # been executed on an MDM-enrolled / profile-enrolled macOS host.
+      # Procedure + pass criterion: see issue #125 and docs/packaging/macos.md
+      # § "Pre-tag verification ritual". CI cannot enforce this on its own —
+      # the Linux executor for PRs cannot exercise CFNetwork — so the
+      # ritual is a human gate. Do not tag without a recorded pass.
       - name: Notarize PKG
         if: env.IS_RELEASE == 'true'
         env:

--- a/.github/workflows/release-macos-pkg.yml
+++ b/.github/workflows/release-macos-pkg.yml
@@ -91,10 +91,13 @@ jobs:
           test -f dist/ai-proxy-0.0.0-dryrun.mobileconfig
           # Distribution PKG's component payload list should mention the binary
           # and the LaunchDaemon plist — quickest mechanical structural check.
-          pkgutil --payload-files dist/ai-proxy-0.0.0-dryrun-universal.pkg \
-            | grep -q '/usr/local/bin/ai-proxy'
-          pkgutil --payload-files dist/ai-proxy-0.0.0-dryrun-universal.pkg \
-            | grep -q '/Library/LaunchDaemons/com.ai-anonymizing-proxy.plist'
+          # pkgutil --payload-files emits paths with a leading './' (relative
+          # to the install location), so grep does not anchor on '^/'.
+          payload=$(pkgutil --payload-files dist/ai-proxy-0.0.0-dryrun-universal.pkg)
+          echo "$payload" | grep -qE 'usr/local/bin/ai-proxy$' \
+            || { echo "::error::PKG payload missing ai-proxy binary"; echo "$payload"; exit 1; }
+          echo "$payload" | grep -qE 'Library/LaunchDaemons/com\.ai-anonymizing-proxy\.plist$' \
+            || { echo "::error::PKG payload missing LaunchDaemon plist"; echo "$payload"; exit 1; }
           plutil -lint dist/ai-proxy-0.0.0-dryrun.mobileconfig
 
           # Discard the unsigned artifacts so they cannot ride into any later

--- a/.github/workflows/release-macos-pkg.yml
+++ b/.github/workflows/release-macos-pkg.yml
@@ -77,11 +77,14 @@ jobs:
             -out    build/dry-run-ca/ca-cert.pem >/dev/null 2>&1
           chmod 0600 build/dry-run-ca/ca-key.pem
 
-          PKG_VERSION=0.0.0-dryrun \
+          # build.sh / mobileconfig/build.sh read VERSION directly; the
+          # Makefile-level PKG_VERSION wraps it. Call the scripts with
+          # VERSION set explicitly since we're bypassing make here.
+          VERSION=0.0.0-dryrun \
           SKIP_SIGN=1 \
           bash packaging/macos/pkg/build.sh
 
-          PKG_VERSION=0.0.0-dryrun \
+          VERSION=0.0.0-dryrun \
           CA_CERT="$PWD/build/dry-run-ca/ca-cert.pem" \
           SKIP_SIGN=1 \
           bash packaging/macos/mobileconfig/build.sh

--- a/.github/workflows/release-macos-pkg.yml
+++ b/.github/workflows/release-macos-pkg.yml
@@ -1,0 +1,205 @@
+name: macOS PKG + .mobileconfig
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'packaging/macos/**'
+      - '.github/workflows/release-macos-pkg.yml'
+      - 'cmd/proxy/**'
+      - 'internal/ca/**'
+      - 'internal/mitm/**'
+      - 'Makefile'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build (macos-latest)
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    env:
+      # PRs don't notarize: Apple rejects re-submissions of identical content
+      # and notarization is a release-time concern. Tag builds notarize+staple.
+      IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify required Secrets present
+        env:
+          MACOS_INSTALLER_CERT_P12: ${{ secrets.MACOS_INSTALLER_CERT_P12 }}
+          MACOS_INSTALLER_CERT_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_PASSWORD }}
+          MACOS_APPLICATION_CERT_P12: ${{ secrets.MACOS_APPLICATION_CERT_P12 }}
+          MACOS_APPLICATION_CERT_PASSWORD: ${{ secrets.MACOS_APPLICATION_CERT_PASSWORD }}
+          MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_APP_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_PASSWORD }}
+          MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+          MACOS_RELEASE_CA_CERT: ${{ secrets.MACOS_RELEASE_CA_CERT }}
+          MACOS_RELEASE_CA_KEY: ${{ secrets.MACOS_RELEASE_CA_KEY }}
+        run: |
+          missing=0
+          for v in MACOS_INSTALLER_CERT_P12 MACOS_INSTALLER_CERT_PASSWORD \
+                   MACOS_APPLICATION_CERT_P12 MACOS_APPLICATION_CERT_PASSWORD \
+                   MACOS_NOTARY_APPLE_ID MACOS_NOTARY_APP_PASSWORD \
+                   MACOS_NOTARY_TEAM_ID MACOS_KEYCHAIN_PASSWORD \
+                   MACOS_RELEASE_CA_CERT MACOS_RELEASE_CA_KEY; do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Required secret $v is missing"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: Set up signing keychain
+        env:
+          MACOS_INSTALLER_CERT_P12: ${{ secrets.MACOS_INSTALLER_CERT_P12 }}
+          MACOS_INSTALLER_CERT_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERT_PASSWORD }}
+          MACOS_APPLICATION_CERT_P12: ${{ secrets.MACOS_APPLICATION_CERT_P12 }}
+          MACOS_APPLICATION_CERT_PASSWORD: ${{ secrets.MACOS_APPLICATION_CERT_PASSWORD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN=build.keychain
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -t 7200 -u "$KEYCHAIN"
+
+          echo "$MACOS_INSTALLER_CERT_P12" | base64 -d > installer.p12
+          security import installer.p12 -k "$KEYCHAIN" -P "$MACOS_INSTALLER_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          rm installer.p12
+
+          echo "$MACOS_APPLICATION_CERT_P12" | base64 -d > app.p12
+          security import app.p12 -k "$KEYCHAIN" -P "$MACOS_APPLICATION_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          rm app.p12
+
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          INSTALLER=$(security find-identity -v -p basic "$KEYCHAIN" \
+                     | grep "Developer ID Installer" | head -1 | awk -F'"' '{print $2}')
+          APP=$(security find-identity -v -p basic "$KEYCHAIN" \
+                | grep "Developer ID Application" | head -1 | awk -F'"' '{print $2}')
+          if [ -z "$INSTALLER" ] || [ -z "$APP" ]; then
+            echo "::error::Could not resolve signing identities from keychain"
+            exit 1
+          fi
+          echo "MACOS_INSTALLER_IDENTITY=$INSTALLER" >> "$GITHUB_ENV"
+          echo "MACOS_APPLICATION_IDENTITY=$APP" >> "$GITHUB_ENV"
+
+      - name: Stage release CA
+        env:
+          MACOS_RELEASE_CA_CERT: ${{ secrets.MACOS_RELEASE_CA_CERT }}
+          MACOS_RELEASE_CA_KEY: ${{ secrets.MACOS_RELEASE_CA_KEY }}
+        run: |
+          mkdir -p build/release-ca
+          echo "$MACOS_RELEASE_CA_CERT" | base64 -d > build/release-ca/ca-cert.pem
+          echo "$MACOS_RELEASE_CA_KEY"  | base64 -d > build/release-ca/ca-key.pem
+          chmod 0600 build/release-ca/ca-key.pem
+          echo "CA_CERT_FILE_FOR_RELEASE=$PWD/build/release-ca/ca-cert.pem" >> "$GITHUB_ENV"
+
+      - name: Build PKG
+        env:
+          PKG_VERSION: ${{ github.ref_name }}
+        run: make package-macos-pkg
+
+      - name: Build .mobileconfig
+        env:
+          PKG_VERSION: ${{ github.ref_name }}
+        run: make package-macos-mobileconfig
+
+      - name: Notarize PKG
+        if: env.IS_RELEASE == 'true'
+        env:
+          NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          NOTARY_APP_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_PASSWORD }}
+          NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+        run: |
+          xcrun notarytool store-credentials notary-profile \
+            --apple-id "$NOTARY_APPLE_ID" \
+            --password "$NOTARY_APP_PASSWORD" \
+            --team-id "$NOTARY_TEAM_ID"
+          for pkg in dist/*.pkg; do
+            PKG_PATH="$pkg" NOTARY_PROFILE=notary-profile bash packaging/macos/pkg/notarize.sh
+          done
+
+      - name: Verify artifacts
+        run: |
+          for pkg in dist/*.pkg; do
+            pkgutil --check-signature "$pkg"
+            if [ "$IS_RELEASE" = "true" ]; then
+              spctl --assess --type install --verbose=2 "$pkg"
+            fi
+          done
+          for mc in dist/*.mobileconfig; do
+            plutil -lint "$mc"
+            /usr/bin/security cms -D -i "$mc" >/dev/null
+          done
+
+      - name: Cleanup release CA
+        if: always()
+        run: rm -rf build/release-ca
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos
+          path: dist/*
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain build.keychain || true
+
+  release:
+    name: Sign + publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@448e3f862ab3ef47aa50ff917776823c9946035b # v7.0.0
+        with:
+          name: macos
+          path: dist/
+
+      - name: Generate checksums
+        working-directory: dist
+        run: |
+          shasum -a 256 *.pkg *.mobileconfig > SHA256SUMS-macos
+          shasum -a 512 *.pkg *.mobileconfig > SHA512SUMS-macos
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6e113b16d7d56d4c136e46ea9d2f80ce5d4be # v3.7.0
+
+      - name: Sign release artifacts (keyless)
+        working-directory: dist
+        run: |
+          for f in *.pkg *.mobileconfig SHA256SUMS-macos SHA512SUMS-macos; do
+            cosign sign-blob --yes \
+              --output-signature "$f.sig" \
+              --output-certificate "$f.cert" \
+              "$f"
+          done
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
+        with:
+          files: dist/*
+          fail_on_unmatched_files: true

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_FLAGS := -ldflags="-s -w"
 CA_CERT    := ca-cert.pem
 CA_KEY     := ca-key.pem
 
-.PHONY: all build run clean test lint security vulncheck check benchmark gen-ca import-ca-macos import-ca-linux import-ca-windows import-ca-macos-user import-ca-linux-user import-ca-windows-user deploy package-linux package-linux-amd64 package-linux-arm64
+.PHONY: all build run clean test lint security vulncheck check benchmark gen-ca import-ca-macos import-ca-linux import-ca-windows import-ca-macos-user import-ca-linux-user import-ca-windows-user deploy package-linux package-linux-amd64 package-linux-arm64 package-macos package-macos-pkg package-macos-mobileconfig
 
 all: build
 
@@ -152,3 +152,23 @@ package-linux-arm64:
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o bin/ai-proxy $(CMD)
 	ARCH=arm64 VERSION=$(PKG_VERSION) $(NFPM) package -f packaging/linux/nfpm.yaml -p deb -t dist/
 	ARCH=arm64 VERSION=$(PKG_VERSION) $(NFPM) package -f packaging/linux/nfpm.yaml -p rpm -t dist/
+
+# --- UEM macOS packaging (Phase 2) ---
+# Both targets are macOS-only. Running on Linux fails fast — pkgbuild,
+# productbuild, codesign, security, and notarytool are macOS-host tools.
+
+package-macos: package-macos-pkg package-macos-mobileconfig
+
+package-macos-pkg:
+	@[ "$$(uname -s)" = "Darwin" ] || { echo "package-macos-pkg requires macOS"; exit 1; }
+	VERSION=$(PKG_VERSION) ARCH=universal \
+	INSTALLER_IDENTITY="$$MACOS_INSTALLER_IDENTITY" \
+	APPLICATION_IDENTITY="$$MACOS_APPLICATION_IDENTITY" \
+	bash packaging/macos/pkg/build.sh
+
+package-macos-mobileconfig:
+	@[ "$$(uname -s)" = "Darwin" ] || { echo "package-macos-mobileconfig requires macOS"; exit 1; }
+	VERSION=$(PKG_VERSION) \
+	CA_CERT=$(CA_CERT_FILE_FOR_RELEASE) \
+	APPLICATION_IDENTITY="$$MACOS_APPLICATION_IDENTITY" \
+	bash packaging/macos/mobileconfig/build.sh

--- a/docs/packaging/README.md
+++ b/docs/packaging/README.md
@@ -5,7 +5,7 @@ Native OS packages for unattended UEM deployment (Intune, JAMF, SCCM, etc.).
 | Platform | Format | Status | Doc |
 |---|---|---|---|
 | Linux  | `.deb`, `.rpm` (amd64, arm64) | shipped | [`linux.md`](./linux.md) |
-| macOS  | `.pkg` + `.mobileconfig`      | planned | _phase 2_ |
+| macOS  | `.pkg` + `.mobileconfig`      | shipped | [`macos.md`](./macos.md) |
 | Windows | MSI                           | planned | _phase 3_ |
 
 Each phase covers silent install, service registration, OS trust-store integration, externalized configuration, and clean uninstall. Source under `packaging/<platform>/`.

--- a/docs/packaging/macos.md
+++ b/docs/packaging/macos.md
@@ -235,6 +235,30 @@ tail -n 200 /var/log/ai-proxy/stderr.log
 | Daemon running but HTTPS sites fail with TLS errors | CA not in System keychain. | `sudo security find-certificate -c "ai-proxy" -p /Library/Keychains/System.keychain` — empty output means trust did not install. Re-run postinstall. |
 | Profile install silently does nothing | Profile not signed, or signed by a non-trusted cert. | `plutil -lint ai-proxy-*.mobileconfig` + `security cms -D -i ai-proxy-*.mobileconfig`. |
 
+## Pre-tag verification ritual
+
+CI cannot verify that the `.mobileconfig` actually causes a profile-enrolled macOS host's CFNetwork stack to route HTTPS through `127.0.0.1:18080` — the workflow runs on a GitHub-hosted runner with no profile installed. Before every `v*` tag push, execute this ritual on a Tart VM, Apple Silicon test host, or MDM-enrolled device. Tracked in issue [#125](https://github.com/laplaque/ai-anonymizing-proxy/issues/125); the `Notarize PKG` step in `release-macos-pkg.yml` references it.
+
+```bash
+# 1. Install PKG + profile
+sudo installer -pkg dist/ai-proxy-<version>-universal.pkg -target /
+sudo profiles install -path dist/ai-proxy-<version>.mobileconfig
+
+# 2. Confirm both are active
+sudo launchctl print system/com.ai-anonymizing-proxy | grep state
+sudo profiles list | grep ai-anonymizing-proxy
+
+# 3. HTTPS interception test — note the absence of --proxy on curl
+curl -k https://httpbin.org/get
+
+# 4. Verify the daemon logged the connection
+tail -n 20 /var/log/ai-proxy/stdout.log | grep httpbin.org
+```
+
+**Pass criterion:** step 4 returns at least one log line referencing `httpbin.org`, proving the profile's global HTTP proxy payload caused CFNetwork to route the unproxied `curl` through the daemon.
+
+Record the result (macOS version + log excerpt) on issue #125 before tagging. If the payload shape needs adjustment for a new macOS major version (e.g., HTTPSEnable / HTTPSProxy keys), open a follow-up PR before the tag.
+
 ## Source
 
 - PKG: `packaging/macos/pkg/` (`build.sh`, `distribution.xml`, `scripts/{postinstall,preuninstall}`, `notarize.sh`)

--- a/docs/packaging/macos.md
+++ b/docs/packaging/macos.md
@@ -19,7 +19,9 @@ Concretely:
 
 - The CA private key lives at `/etc/ai-proxy/ca-key.pem`, mode `0640`, owned by the `_aiproxy` service user. Protect it with the same rigour you'd apply to a host SSH key.
 - The CA public cert is trusted in `/Library/Keychains/System.keychain` via `security add-trusted-cert -d -r trustRoot`.
-- The PKG generates a fresh CA per host on first install (preserved on upgrade). The **`.mobileconfig` deploys the release CA** baked in at build time — every host installed via the .mobileconfig route trusts the same CA. Rotation requires re-issuing the profile and pushing it to every device.
+- The PKG generates a fresh CA per host on first install (preserved on upgrade) — blast radius of a key compromise is **one host**.
+- The **`.mobileconfig` deploys the release CA** baked in at build time. That CA is backed by a single repository secret (`MACOS_RELEASE_CA_KEY`) — compromise of that secret confers the ability to mint TLS certs trusted by **every device in the fleet** that installed via the profile, simultaneously. The `.mobileconfig` route's blast radius is the entire managed fleet, not one host. Treat the secret with that threat model in mind: restrict who can read it, rotate it on a schedule, and prefer the per-host PKG path for populations where a per-host CA is acceptable.
+- Rotation of the .mobileconfig CA requires re-issuing the profile and pushing it to every device (see [Release CA rotation](#release-ca-rotation)).
 - Uninstall removes the CA from the System keychain (see [Uninstall](#uninstall)).
 - If the LaunchDaemon fails to start during postinstall, the CA is removed from the System keychain and the install aborts non-zero — installed-but-not-intercepting cannot occur (per CLAUDE.md Invariant #1).
 
@@ -188,14 +190,50 @@ Checksums are published as `SHA256SUMS-macos` and `SHA512SUMS-macos` alongside t
 
 ## Release CA rotation
 
-The `.mobileconfig` embeds the CA at build time. If the CA private key is suspected compromised:
+The `.mobileconfig` embeds the release CA at build time. PKG hosts do **not** use this CA — they generate their own per-host CA in `postinstall` (idempotent on upgrade). The procedures differ by deployment route:
+
+### `.mobileconfig` / MDM route
+
+If the release CA private key is suspected compromised:
 
 1. Generate a fresh CA pair locally.
 2. Re-encode both PEMs as base64 and update the `MACOS_RELEASE_CA_CERT` / `MACOS_RELEASE_CA_KEY` repository secrets.
-3. Cut a new release tag — the CI workflow rebuilds the .mobileconfig (and embeds the new CA in PKG-installed hosts' fallback path).
+3. Cut a new release tag — the CI workflow rebuilds the `.mobileconfig` with the new CA embedded.
 4. Push the new profile to every managed device via JAMF / MDM. The old profile is replaced; old CA trust is removed.
 
-In-place rotation via a forthcoming `ai-proxy install --rotate-ca` command is planned (Phase 6). Until then, rotation = uninstall + reinstall.
+### PKG route
+
+PKG hosts each have their own CA at `/etc/ai-proxy/ca-cert.pem` and `/etc/ai-proxy/ca-key.pem`. The release CA from CI never reaches them. Rotation is per-host:
+
+```bash
+sudo bash /usr/local/share/ai-proxy/uninstall.sh   # removes old CA trust + daemon
+sudo pkgutil --forget com.ai-anonymizing-proxy.pkg
+sudo rm -f /etc/ai-proxy/ca-cert.pem /etc/ai-proxy/ca-key.pem
+sudo installer -pkg ai-proxy-<version>-universal.pkg -target /
+```
+
+In-place rotation via a forthcoming `ai-proxy install --rotate-ca` command is planned (Phase 6). Until then, the PKG-route rotation is uninstall + remove cert + reinstall.
+
+## Troubleshooting
+
+```bash
+# Daemon state — look at LastExitStatus, PID, state fields.
+sudo launchctl print system/com.ai-anonymizing-proxy
+
+# Structured log — anything the daemon wrote to unified log in the last hour.
+log show --predicate 'process == "ai-proxy"' --info --last 1h
+
+# Stdout/stderr captured by launchd.
+tail -n 200 /var/log/ai-proxy/stderr.log
+```
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `postinstall exit code 1` | LaunchDaemon failed to load; CA trust **was** rolled back. | Check `launchctl print` for the diagnostic; common causes: port collision on 18080/18081, missing dir under `/var/`. Re-run `installer` once the cause is fixed. |
+| `postinstall exit code 2` | LaunchDaemon failed AND rollback could not remove the CA. | **PII may leak.** Manually delete the CA: `sudo security delete-certificate -c "ai-proxy CA" /Library/Keychains/System.keychain`. |
+| `installer` reports "package signed by unidentified developer" | PKG was modified after signing, or the host has Gatekeeper disabled in a way that surfaces stricter checks. | Re-download the PKG; verify with `pkgutil --check-signature`. |
+| Daemon running but HTTPS sites fail with TLS errors | CA not in System keychain. | `sudo security find-certificate -c "ai-proxy" -p /Library/Keychains/System.keychain` — empty output means trust did not install. Re-run postinstall. |
+| Profile install silently does nothing | Profile not signed, or signed by a non-trusted cert. | `plutil -lint ai-proxy-*.mobileconfig` + `security cms -D -i ai-proxy-*.mobileconfig`. |
 
 ## Source
 

--- a/docs/packaging/macos.md
+++ b/docs/packaging/macos.md
@@ -1,0 +1,205 @@
+# macOS Packaging
+
+`ai-proxy` ships for macOS as two artifacts:
+
+| Artifact | Use case |
+|---|---|
+| `ai-proxy-<version>-universal.pkg` | Self-managed install or JAMF "PKG" policy. Universal binary (arm64 + amd64). |
+| `ai-proxy-<version>.mobileconfig` | JAMF / MDM declarative deployment — pushes CA trust + global HTTP proxy settings. |
+
+Both are signed with an Apple Developer ID certificate. The PKG is additionally notarized and stapled, so it installs offline without contacting Apple at install time.
+
+Minimum macOS version: **12.0 (Monterey)**.
+
+## ⚠ Security posture — read before fleet deployment
+
+Installing this package adds a host-local Certificate Authority to the macOS System keychain trust store. **After install, this host trusts an `ai-proxy`-controlled CA capable of MITM-ing any HTTPS connection originating from it.** Anyone with read access to `/etc/ai-proxy/ca-key.pem` can mint TLS certificates that Safari, every CLI, Xcode, etc. will accept without warning.
+
+Concretely:
+
+- The CA private key lives at `/etc/ai-proxy/ca-key.pem`, mode `0640`, owned by the `_aiproxy` service user. Protect it with the same rigour you'd apply to a host SSH key.
+- The CA public cert is trusted in `/Library/Keychains/System.keychain` via `security add-trusted-cert -d -r trustRoot`.
+- The PKG generates a fresh CA per host on first install (preserved on upgrade). The **`.mobileconfig` deploys the release CA** baked in at build time — every host installed via the .mobileconfig route trusts the same CA. Rotation requires re-issuing the profile and pushing it to every device.
+- Uninstall removes the CA from the System keychain (see [Uninstall](#uninstall)).
+- If the LaunchDaemon fails to start during postinstall, the CA is removed from the System keychain and the install aborts non-zero — installed-but-not-intercepting cannot occur (per CLAUDE.md Invariant #1).
+
+See [docs/tls-mitm.md](../tls-mitm.md) for the broader MITM architecture and threat model.
+
+## Install — PKG
+
+Double-click the `.pkg` in Finder, or silently:
+
+```bash
+sudo installer -pkg ai-proxy-<version>-universal.pkg -target /
+```
+
+Gatekeeper accepts the package because it is signed (Developer ID Installer) and notarized + stapled.
+
+The package:
+
+- Installs the universal binary at `/usr/local/bin/ai-proxy`
+- Creates the `_aiproxy` system user (hidden, no shell, no home; UID auto-allocated in the 220–400 range)
+- Generates a CA cert + key under `/etc/ai-proxy/` if not already present
+- Trusts the CA in the System keychain via `security add-trusted-cert`
+- Installs the LaunchDaemon plist at `/Library/LaunchDaemons/com.ai-anonymizing-proxy.plist`
+- Loads + starts the daemon via `launchctl bootstrap system …`
+- Ships the uninstall script at `/usr/local/share/ai-proxy/uninstall.sh`
+
+If postinstall cannot load the LaunchDaemon, it removes the CA from the System keychain and exits non-zero.
+
+### UID allocation fallback
+
+The postinstall script scans UIDs 220–400 for a free slot. If that range is fully occupied on a heavily customized host, allocate `_aiproxy` manually before installing:
+
+```bash
+sudo dscl . -create /Groups/_aiproxy PrimaryGroupID <free-uid>
+sudo dscl . -create /Users/_aiproxy UniqueID <free-uid>
+sudo dscl . -create /Users/_aiproxy PrimaryGroupID <free-uid>
+sudo dscl . -create /Users/_aiproxy NFSHomeDirectory /var/empty
+sudo dscl . -create /Users/_aiproxy UserShell /usr/bin/false
+sudo dscl . -create /Users/_aiproxy IsHidden 1
+sudo dscl . -create /Users/_aiproxy Password "*"
+```
+
+## Configure
+
+The LaunchDaemon does **not** source an env file — macOS launchd reads env vars only from the plist's `EnvironmentVariables` dict.
+
+To change a value, edit `/Library/LaunchDaemons/com.ai-anonymizing-proxy.plist` (or override at MDM-deploy time) and re-bootstrap:
+
+```bash
+sudo launchctl bootout system/com.ai-anonymizing-proxy
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist
+```
+
+The file at `/etc/ai-proxy/ai-proxy.env` is shipped for parity with Linux but is informational on macOS — admins migrating from Linux can read it to remind themselves of the variable names and defaults.
+
+| Variable | Default in plist | Purpose |
+|---|---|---|
+| `BIND_ADDRESS` | `127.0.0.1` | Listen address. |
+| `PROXY_PORT` | `18080` | MITM proxy port. Differs from Linux (8080) to avoid collisions with common dev servers on macOS. |
+| `MANAGEMENT_PORT` | `18081` | Management API port. |
+| `CA_CERT_FILE` | `/etc/ai-proxy/ca-cert.pem` | CA cert path. |
+| `CA_KEY_FILE` | `/etc/ai-proxy/ca-key.pem` | CA key path. |
+| `ENABLED_PACKS` | `SECRETS,GLOBAL,DE` | PII detection packs (order matters — `SECRETS` must precede `GLOBAL`). |
+| `USE_AI_DETECTION` | `false` | Enable Ollama-backed PII detection. |
+| `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error`. |
+
+The structured config at `/etc/ai-proxy/proxy-config.json` is honored as a fallback and preserved across upgrades.
+
+## Verify
+
+```bash
+# Service state
+sudo launchctl print system/com.ai-anonymizing-proxy | head -40
+
+# Logs
+tail -f /var/log/ai-proxy/stdout.log /var/log/ai-proxy/stderr.log
+
+# Management API
+curl http://127.0.0.1:18081/status
+
+# Trusted CA in the System keychain
+sudo security find-certificate -c "ai-proxy" -p /Library/Keychains/System.keychain
+```
+
+## Install — `.mobileconfig` (JAMF / MDM)
+
+The `.mobileconfig` profile carries two payloads:
+
+1. **`com.apple.security.root`** — the release CA, trusted as a root in the System keychain.
+2. **`com.apple.proxy.http.global`** — a manual HTTP proxy at `127.0.0.1:18080`.
+
+It does **not** install the binary or the LaunchDaemon. The profile is meant to be deployed in tandem with the PKG (PKG installs the daemon, profile establishes trust + proxy settings).
+
+### Manual install
+
+```bash
+sudo profiles install -path ai-proxy-<version>.mobileconfig
+sudo profiles list | grep ai-proxy
+```
+
+Or double-click the file in Finder and approve in **System Settings → Privacy & Security → Profiles**.
+
+### JAMF deployment
+
+In JAMF Pro:
+
+1. **Computers → Configuration Profiles → Upload** the signed `.mobileconfig`.
+2. Scope to the target smart group.
+3. (Optional) Wrap the PKG in a Policy that runs alongside the profile, so the LaunchDaemon is present on every device that trusts the CA.
+
+JAMF will treat the profile's `PayloadRemovalDisallowed = false` as removable — admin re-scoping pulls the profile and removes both the CA trust and the proxy settings.
+
+### Verify the profile
+
+```bash
+sudo profiles list                                          # is it installed?
+plutil -lint ai-proxy-<version>.mobileconfig                # XML valid?
+/usr/bin/security cms -D -i ai-proxy-<version>.mobileconfig | head   # signed payload
+```
+
+## Upgrade
+
+`installer -pkg` reinstalls the binary, plist, and uninstall script. `/etc/ai-proxy/proxy-config.json` and the existing CA cert + key are preserved.
+
+For .mobileconfig: increment `PayloadVersion` in the source and re-push — MDMs replace the existing profile in place.
+
+## Uninstall
+
+```bash
+sudo bash /usr/local/share/ai-proxy/uninstall.sh
+sudo pkgutil --forget com.ai-anonymizing-proxy.pkg
+```
+
+This stops the daemon, removes the CA from the System keychain, and removes the LaunchDaemon plist. Files under `/etc/ai-proxy/` are preserved — purge manually if desired:
+
+```bash
+sudo rm -rf /etc/ai-proxy /var/lib/ai-proxy /var/log/ai-proxy
+```
+
+For the `.mobileconfig`:
+
+```bash
+sudo profiles remove -identifier com.ai-anonymizing-proxy.profile
+```
+
+## Verify package signatures
+
+Every release artifact is signed via Sigstore cosign (keyless, OIDC-bound):
+
+```bash
+cosign verify-blob \
+  --certificate ai-proxy-<version>-universal.pkg.cert \
+  --signature   ai-proxy-<version>-universal.pkg.sig \
+  --certificate-identity-regexp 'https://github.com/laplaque/ai-anonymizing-proxy/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ai-proxy-<version>-universal.pkg
+```
+
+Apple-level signature checks:
+
+```bash
+pkgutil --check-signature ai-proxy-<version>-universal.pkg
+spctl --assess --type install --verbose=2 ai-proxy-<version>-universal.pkg
+```
+
+Checksums are published as `SHA256SUMS-macos` and `SHA512SUMS-macos` alongside the artifacts.
+
+## Release CA rotation
+
+The `.mobileconfig` embeds the CA at build time. If the CA private key is suspected compromised:
+
+1. Generate a fresh CA pair locally.
+2. Re-encode both PEMs as base64 and update the `MACOS_RELEASE_CA_CERT` / `MACOS_RELEASE_CA_KEY` repository secrets.
+3. Cut a new release tag — the CI workflow rebuilds the .mobileconfig (and embeds the new CA in PKG-installed hosts' fallback path).
+4. Push the new profile to every managed device via JAMF / MDM. The old profile is replaced; old CA trust is removed.
+
+In-place rotation via a forthcoming `ai-proxy install --rotate-ca` command is planned (Phase 6). Until then, rotation = uninstall + reinstall.
+
+## Source
+
+- PKG: `packaging/macos/pkg/` (`build.sh`, `distribution.xml`, `scripts/{postinstall,preuninstall}`, `notarize.sh`)
+- .mobileconfig: `packaging/macos/mobileconfig/` (`ai-proxy.mobileconfig.tmpl`, `build.sh`)
+- Build target: `make package-macos`
+- CI workflow: `.github/workflows/release-macos-pkg.yml`

--- a/packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl
+++ b/packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl
@@ -26,6 +26,14 @@
       <data>__CA_DER_BASE64__</data>
     </dict>
     <!-- Global HTTP proxy payload -->
+    <!--
+      Exceptions:
+        - 127.0.0.1 / localhost: prevents the daemon's own loopback listener
+          from proxying through itself (loop).
+        - *.local: preserves mDNS / Bonjour service discovery, which Apple
+          devices use heavily on enterprise LANs.
+        - 169.254/16: link-local (captive-portal detection, DHCP edge cases).
+    -->
     <dict>
       <key>PayloadType</key><string>com.apple.proxy.http.global</string>
       <key>PayloadIdentifier</key><string>com.ai-anonymizing-proxy.proxy</string>
@@ -36,6 +44,13 @@
       <key>ProxyServer</key><string>127.0.0.1</string>
       <key>ProxyServerPort</key><integer>18080</integer>
       <key>ProxyCaptiveLoginAllowed</key><true/>
+      <key>ExceptionsList</key>
+      <array>
+        <string>127.0.0.1</string>
+        <string>localhost</string>
+        <string>*.local</string>
+        <string>169.254/16</string>
+      </array>
     </dict>
   </array>
 </dict>

--- a/packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl
+++ b/packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                       "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadType</key><string>Configuration</string>
+  <key>PayloadDisplayName</key><string>AI Anonymizing Proxy</string>
+  <key>PayloadDescription</key><string>Trusts the ai-proxy CA and routes HTTP/HTTPS through the local proxy.</string>
+  <key>PayloadIdentifier</key><string>com.ai-anonymizing-proxy.profile</string>
+  <key>PayloadOrganization</key><string>laplaque</string>
+  <key>PayloadUUID</key><string>__PROFILE_UUID__</string>
+  <key>PayloadVersion</key><integer>1</integer>
+  <key>PayloadScope</key><string>System</string>
+  <key>PayloadRemovalDisallowed</key><false/>
+  <key>PayloadContent</key>
+  <array>
+    <!-- CA trust payload -->
+    <dict>
+      <key>PayloadType</key><string>com.apple.security.root</string>
+      <key>PayloadIdentifier</key><string>com.ai-anonymizing-proxy.ca</string>
+      <key>PayloadUUID</key><string>__CA_PAYLOAD_UUID__</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>ai-proxy CA</string>
+      <key>PayloadCertificateFileName</key><string>ai-proxy-ca.cer</string>
+      <key>PayloadContent</key>
+      <data>__CA_DER_BASE64__</data>
+    </dict>
+    <!-- Global HTTP proxy payload -->
+    <dict>
+      <key>PayloadType</key><string>com.apple.proxy.http.global</string>
+      <key>PayloadIdentifier</key><string>com.ai-anonymizing-proxy.proxy</string>
+      <key>PayloadUUID</key><string>__PROXY_PAYLOAD_UUID__</string>
+      <key>PayloadVersion</key><integer>1</integer>
+      <key>PayloadDisplayName</key><string>ai-proxy HTTP Proxy</string>
+      <key>ProxyType</key><string>Manual</string>
+      <key>ProxyServer</key><string>127.0.0.1</string>
+      <key>ProxyServerPort</key><integer>18080</integer>
+      <key>ProxyCaptiveLoginAllowed</key><true/>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/packaging/macos/mobileconfig/build.sh
+++ b/packaging/macos/mobileconfig/build.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Render and sign the ai-proxy .mobileconfig profile.
+# Render and (optionally) sign the ai-proxy .mobileconfig profile.
 #
 # Required env vars:
 #   VERSION              — semver for output filename
-#   CA_CERT              — path to the release CA cert (PEM) to embed
+#   CA_CERT              — path to the CA cert (PEM) to embed
+#
+# Required when SKIP_SIGN is unset (the release path):
 #   APPLICATION_IDENTITY — "Developer ID Application: ..." cert name in keychain
+#
+# Optional:
+#   SKIP_SIGN=1          — produce an unsigned .mobileconfig. Used by
+#                          PR-event CI to exercise the template substitution,
+#                          base64 CA encoding, and plutil-lint path without
+#                          requiring Apple signing secrets. The resulting
+#                          profile cannot be installed on a real Mac; it is
+#                          for structural verification only.
 
 : "${VERSION:?VERSION required}"
 : "${CA_CERT:?CA_CERT required (path to PEM)}"
-: "${APPLICATION_IDENTITY:?APPLICATION_IDENTITY required}"
+SKIP_SIGN="${SKIP_SIGN:-0}"
+
+if [ "$SKIP_SIGN" != "1" ]; then
+  : "${APPLICATION_IDENTITY:?APPLICATION_IDENTITY required (set SKIP_SIGN=1 for unsigned dry-run)}"
+fi
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 TMPL="$ROOT/packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl"
@@ -29,8 +43,13 @@ sed \
 
 plutil -lint "$OUT.unsigned"
 
-# CMS-sign the profile. Same Developer ID Application cert used for the binary.
-/usr/bin/security cms -S -N "$APPLICATION_IDENTITY" -i "$OUT.unsigned" -o "$OUT"
-rm "$OUT.unsigned"
-
-echo "Signed $OUT"
+if [ "$SKIP_SIGN" = "1" ]; then
+  echo "SKIP_SIGN=1 — leaving .mobileconfig unsigned."
+  mv "$OUT.unsigned" "$OUT"
+  echo "Built $OUT (unsigned, for structural verification only — do NOT distribute)."
+else
+  # CMS-sign the profile. Same Developer ID Application cert used for the binary.
+  /usr/bin/security cms -S -N "$APPLICATION_IDENTITY" -i "$OUT.unsigned" -o "$OUT"
+  rm "$OUT.unsigned"
+  echo "Signed $OUT"
+fi

--- a/packaging/macos/mobileconfig/build.sh
+++ b/packaging/macos/mobileconfig/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Render and sign the ai-proxy .mobileconfig profile.
+#
+# Required env vars:
+#   VERSION              — semver for output filename
+#   CA_CERT              — path to the release CA cert (PEM) to embed
+#   APPLICATION_IDENTITY — "Developer ID Application: ..." cert name in keychain
+
+: "${VERSION:?VERSION required}"
+: "${CA_CERT:?CA_CERT required (path to PEM)}"
+: "${APPLICATION_IDENTITY:?APPLICATION_IDENTITY required}"
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+TMPL="$ROOT/packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl"
+DIST="$ROOT/dist"
+mkdir -p "$DIST"
+OUT="$DIST/ai-proxy-${VERSION}.mobileconfig"
+
+CA_DER_BASE64=$(openssl x509 -in "$CA_CERT" -outform DER | base64 | tr -d '\n')
+
+sed \
+  -e "s/__PROFILE_UUID__/$(uuidgen)/" \
+  -e "s/__CA_PAYLOAD_UUID__/$(uuidgen)/" \
+  -e "s/__PROXY_PAYLOAD_UUID__/$(uuidgen)/" \
+  -e "s|__CA_DER_BASE64__|$CA_DER_BASE64|" \
+  "$TMPL" > "$OUT.unsigned"
+
+plutil -lint "$OUT.unsigned"
+
+# CMS-sign the profile. Same Developer ID Application cert used for the binary.
+/usr/bin/security cms -S -N "$APPLICATION_IDENTITY" -i "$OUT.unsigned" -o "$OUT"
+rm "$OUT.unsigned"
+
+echo "Signed $OUT"

--- a/packaging/macos/pkg/ai-proxy.env
+++ b/packaging/macos/pkg/ai-proxy.env
@@ -6,18 +6,20 @@
 #   sudo launchctl bootout system/com.ai-anonymizing-proxy
 #   sudo launchctl bootstrap system /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist
 #
-# This file is shipped verbatim with the Linux env file to preserve parity for
-# admins managing fleets across both OSes.
+# The default values below match the plist exactly. macOS uses different
+# ports than Linux (18080/18081 vs 8080/8081) to avoid collisions with
+# common dev servers — keep this file and the plist in sync if you edit
+# either.
 
 # Bind address — defaults to 127.0.0.1 (loopback only).
 # Set to 0.0.0.0 to listen on all interfaces (NOT recommended outside containers).
 BIND_ADDRESS=127.0.0.1
 
 # Listen port for the MITM proxy.
-PROXY_PORT=8080
+PROXY_PORT=18080
 
 # Management API port (status, domain registry, runtime control).
-MANAGEMENT_PORT=8081
+MANAGEMENT_PORT=18081
 
 # Upstream HTTP proxy (optional). Leave unset for direct egress.
 #UPSTREAM_PROXY=

--- a/packaging/macos/pkg/ai-proxy.env
+++ b/packaging/macos/pkg/ai-proxy.env
@@ -1,0 +1,51 @@
+# /etc/ai-proxy/ai-proxy.env (macOS) — INFORMATIONAL ONLY.
+#
+# Unlike Linux, the launchd daemon on macOS does NOT source this file.
+# The live values are baked into /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist
+# under the EnvironmentVariables dict. To change a value, edit the plist and run:
+#   sudo launchctl bootout system/com.ai-anonymizing-proxy
+#   sudo launchctl bootstrap system /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist
+#
+# This file is shipped verbatim with the Linux env file to preserve parity for
+# admins managing fleets across both OSes.
+
+# Bind address — defaults to 127.0.0.1 (loopback only).
+# Set to 0.0.0.0 to listen on all interfaces (NOT recommended outside containers).
+BIND_ADDRESS=127.0.0.1
+
+# Listen port for the MITM proxy.
+PROXY_PORT=8080
+
+# Management API port (status, domain registry, runtime control).
+MANAGEMENT_PORT=8081
+
+# Upstream HTTP proxy (optional). Leave unset for direct egress.
+#UPSTREAM_PROXY=
+
+# CA cert and key — used to MITM HTTPS. Generated at install time.
+CA_CERT_FILE=/etc/ai-proxy/ca-cert.pem
+CA_KEY_FILE=/etc/ai-proxy/ca-key.pem
+
+# Comma-separated list of enabled detection packs.
+# Order matters — SECRETS must precede GLOBAL.
+ENABLED_PACKS=SECRETS,GLOBAL,DE
+
+# Enable AI-enhanced detection via local Ollama sidecar (requires Ollama).
+# Set to "false" to disable.
+USE_AI_DETECTION=false
+
+# Ollama endpoint + model (only used when USE_AI_DETECTION is true).
+#OLLAMA_ENDPOINT=http://localhost:11434
+#OLLAMA_MODEL=qwen2.5:3b
+#OLLAMA_MAX_CONCURRENT=1
+#OLLAMA_CACHE_FILE=/var/lib/ai-proxy/ollama-cache.db
+#AI_CONFIDENCE_THRESHOLD=0.7
+
+# Management API bearer token (optional; leave unset to disable auth).
+#MANAGEMENT_TOKEN=
+
+# Log level: debug, info, warn, error.
+LOG_LEVEL=info
+
+# Pack decay rate (likelihood multiplier per pack position).
+#PACK_DECAY_RATE=0.05

--- a/packaging/macos/pkg/build.sh
+++ b/packaging/macos/pkg/build.sh
@@ -76,10 +76,18 @@ pkgbuild \
   --scripts "$ROOT/packaging/macos/pkg/scripts" \
   "$COMPONENT"
 
-# 5. Build the distribution package, signed with Developer ID Installer
+# 5. Build the distribution package, signed with Developer ID Installer.
+# Render distribution.xml with the real version so pkgutil --pkg-info and
+# Installer.app upgrade-detection logic see a meaningful version number
+# instead of the placeholder.
+DIST_XML="$ROOT/build/macos/distribution.xml"
+mkdir -p "$(dirname "$DIST_XML")"
+sed "s/__PKG_VERSION__/${VERSION}/g" \
+  "$ROOT/packaging/macos/pkg/distribution.xml" > "$DIST_XML"
+
 PRODUCT="$DIST/ai-proxy-${VERSION}-${ARCH}.pkg"
 productbuild \
-  --distribution "$ROOT/packaging/macos/pkg/distribution.xml" \
+  --distribution "$DIST_XML" \
   --package-path "$DIST" \
   --sign "${INSTALLER_IDENTITY:?INSTALLER_IDENTITY required}" \
   "$PRODUCT"

--- a/packaging/macos/pkg/build.sh
+++ b/packaging/macos/pkg/build.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a signed Apple Installer .pkg for ai-proxy.
+#
+# Required env vars (set by Makefile or CI):
+#   VERSION              — semver, no 'v' prefix
+#   ARCH                 — universal | arm64 | amd64 (default: universal)
+#   INSTALLER_IDENTITY   — name of "Developer ID Installer: ..." cert in keychain
+#   APPLICATION_IDENTITY — name of "Developer ID Application: ..." cert
+#
+# Notarization is performed separately by notarize.sh.
+
+: "${VERSION:?VERSION required}"
+: "${ARCH:=universal}"
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+STAGING="$ROOT/build/macos/pkg-staging"
+DIST="$ROOT/dist"
+PKG_ID="com.ai-anonymizing-proxy.pkg"
+
+rm -rf "$STAGING"
+mkdir -p "$STAGING" "$DIST" "$ROOT/bin"
+
+# 1. Build binary (universal by default)
+case "$ARCH" in
+  universal)
+    GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" \
+      -o "$ROOT/bin/ai-proxy-amd64" ./cmd/proxy
+    GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" \
+      -o "$ROOT/bin/ai-proxy-arm64" ./cmd/proxy
+    lipo -create -output "$ROOT/bin/ai-proxy" \
+      "$ROOT/bin/ai-proxy-amd64" "$ROOT/bin/ai-proxy-arm64"
+    ;;
+  arm64|amd64)
+    GOOS=darwin GOARCH="$ARCH" CGO_ENABLED=0 go build -ldflags="-s -w" \
+      -o "$ROOT/bin/ai-proxy" ./cmd/proxy
+    ;;
+  *)
+    echo "Unknown ARCH: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+# 2. Sign the binary with Developer ID Application + hardened runtime
+codesign --sign "${APPLICATION_IDENTITY:?APPLICATION_IDENTITY required}" \
+  --options runtime --timestamp --force \
+  "$ROOT/bin/ai-proxy"
+
+# 3. Stage payload
+install -d -m 0755 "$STAGING/usr/local/bin"
+install -m 0755 "$ROOT/bin/ai-proxy" "$STAGING/usr/local/bin/ai-proxy"
+
+install -d -m 0755 "$STAGING/Library/LaunchDaemons"
+install -m 0644 "$ROOT/packaging/macos/pkg/com.ai-anonymizing-proxy.plist" \
+  "$STAGING/Library/LaunchDaemons/com.ai-anonymizing-proxy.plist"
+
+install -d -m 0755 "$STAGING/etc/ai-proxy"
+install -m 0644 "$ROOT/packaging/macos/pkg/proxy-config.json.default" \
+  "$STAGING/etc/ai-proxy/proxy-config.json"
+install -m 0644 "$ROOT/packaging/macos/pkg/ai-proxy.env" \
+  "$STAGING/etc/ai-proxy/ai-proxy.env"
+
+# Ship the uninstall script — pkgbuild has no native uninstall hook on macOS.
+install -d -m 0755 "$STAGING/usr/local/share/ai-proxy"
+install -m 0755 "$ROOT/packaging/macos/pkg/scripts/preuninstall" \
+  "$STAGING/usr/local/share/ai-proxy/uninstall.sh"
+
+# 4. Build the component package
+COMPONENT="$DIST/ai-proxy-component.pkg"
+pkgbuild \
+  --root "$STAGING" \
+  --identifier "$PKG_ID" \
+  --version "$VERSION" \
+  --install-location "/" \
+  --scripts "$ROOT/packaging/macos/pkg/scripts" \
+  "$COMPONENT"
+
+# 5. Build the distribution package, signed with Developer ID Installer
+PRODUCT="$DIST/ai-proxy-${VERSION}-${ARCH}.pkg"
+productbuild \
+  --distribution "$ROOT/packaging/macos/pkg/distribution.xml" \
+  --package-path "$DIST" \
+  --sign "${INSTALLER_IDENTITY:?INSTALLER_IDENTITY required}" \
+  "$PRODUCT"
+
+# Component package is an intermediate; the distribution PKG is the deliverable.
+rm -f "$COMPONENT"
+
+# 6. Verify signature
+pkgutil --check-signature "$PRODUCT"
+
+echo "Built $PRODUCT"
+echo "Next: notarize.sh"

--- a/packaging/macos/pkg/build.sh
+++ b/packaging/macos/pkg/build.sh
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build a signed Apple Installer .pkg for ai-proxy.
+# Build an Apple Installer .pkg for ai-proxy.
 #
 # Required env vars (set by Makefile or CI):
 #   VERSION              — semver, no 'v' prefix
 #   ARCH                 — universal | arm64 | amd64 (default: universal)
+#
+# Required when SKIP_SIGN is unset (the release path):
 #   INSTALLER_IDENTITY   — name of "Developer ID Installer: ..." cert in keychain
 #   APPLICATION_IDENTITY — name of "Developer ID Application: ..." cert
 #
-# Notarization is performed separately by notarize.sh.
+# Optional:
+#   SKIP_SIGN=1          — build an unsigned PKG. Used by PR-event CI to
+#                          exercise the mechanical build path (payload staging,
+#                          lipo, pkgbuild, productbuild, distribution.xml
+#                          substitution) without requiring Apple signing
+#                          secrets. The resulting PKG cannot be installed on
+#                          a real Mac; it is for structural verification only.
+#                          See N1 in PR #123 review.
+#
+# Notarization is performed separately by notarize.sh (release path only).
 
 : "${VERSION:?VERSION required}"
 : "${ARCH:=universal}"
+SKIP_SIGN="${SKIP_SIGN:-0}"
+
+if [ "$SKIP_SIGN" != "1" ]; then
+  : "${INSTALLER_IDENTITY:?INSTALLER_IDENTITY required (set SKIP_SIGN=1 for unsigned dry-run)}"
+  : "${APPLICATION_IDENTITY:?APPLICATION_IDENTITY required (set SKIP_SIGN=1 for unsigned dry-run)}"
+fi
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 STAGING="$ROOT/build/macos/pkg-staging"
@@ -43,9 +60,13 @@ case "$ARCH" in
 esac
 
 # 2. Sign the binary with Developer ID Application + hardened runtime
-codesign --sign "${APPLICATION_IDENTITY:?APPLICATION_IDENTITY required}" \
-  --options runtime --timestamp --force \
-  "$ROOT/bin/ai-proxy"
+if [ "$SKIP_SIGN" = "1" ]; then
+  echo "SKIP_SIGN=1 — skipping codesign on binary."
+else
+  codesign --sign "$APPLICATION_IDENTITY" \
+    --options runtime --timestamp --force \
+    "$ROOT/bin/ai-proxy"
+fi
 
 # 3. Stage payload
 install -d -m 0755 "$STAGING/usr/local/bin"
@@ -76,27 +97,42 @@ pkgbuild \
   --scripts "$ROOT/packaging/macos/pkg/scripts" \
   "$COMPONENT"
 
-# 5. Build the distribution package, signed with Developer ID Installer.
+# 5. Build the distribution package (signed with Developer ID Installer on
+# release; unsigned on PR dry-run).
 # Render distribution.xml with the real version so pkgutil --pkg-info and
-# Installer.app upgrade-detection logic see a meaningful version number
-# instead of the placeholder.
+# Installer.app upgrade-detection logic see a meaningful version number.
 DIST_XML="$ROOT/build/macos/distribution.xml"
 mkdir -p "$(dirname "$DIST_XML")"
 sed "s/__PKG_VERSION__/${VERSION}/g" \
   "$ROOT/packaging/macos/pkg/distribution.xml" > "$DIST_XML"
 
 PRODUCT="$DIST/ai-proxy-${VERSION}-${ARCH}.pkg"
-productbuild \
-  --distribution "$DIST_XML" \
-  --package-path "$DIST" \
-  --sign "${INSTALLER_IDENTITY:?INSTALLER_IDENTITY required}" \
-  "$PRODUCT"
+if [ "$SKIP_SIGN" = "1" ]; then
+  echo "SKIP_SIGN=1 — building unsigned distribution PKG."
+  productbuild \
+    --distribution "$DIST_XML" \
+    --package-path "$DIST" \
+    "$PRODUCT"
+else
+  productbuild \
+    --distribution "$DIST_XML" \
+    --package-path "$DIST" \
+    --sign "$INSTALLER_IDENTITY" \
+    "$PRODUCT"
+fi
 
 # Component package is an intermediate; the distribution PKG is the deliverable.
 rm -f "$COMPONENT"
 
-# 6. Verify signature
-pkgutil --check-signature "$PRODUCT"
+# 6. Verify signature (release path only — pkgutil --check-signature on an
+# unsigned PKG would exit non-zero by design).
+if [ "$SKIP_SIGN" != "1" ]; then
+  pkgutil --check-signature "$PRODUCT"
+fi
 
 echo "Built $PRODUCT"
-echo "Next: notarize.sh"
+if [ "$SKIP_SIGN" = "1" ]; then
+  echo "Unsigned — for structural verification only. Do NOT distribute."
+else
+  echo "Next: notarize.sh"
+fi

--- a/packaging/macos/pkg/com.ai-anonymizing-proxy.plist
+++ b/packaging/macos/pkg/com.ai-anonymizing-proxy.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                       "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.ai-anonymizing-proxy</string>
+  <key>ProgramArguments</key>
+  <array><string>/usr/local/bin/ai-proxy</string></array>
+  <key>UserName</key><string>_aiproxy</string>
+  <key>GroupName</key><string>_aiproxy</string>
+  <key>WorkingDirectory</key><string>/var/lib/ai-proxy</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>BIND_ADDRESS</key><string>127.0.0.1</string>
+    <key>PROXY_PORT</key><string>18080</string>
+    <key>MANAGEMENT_PORT</key><string>18081</string>
+    <key>CA_CERT_FILE</key><string>/etc/ai-proxy/ca-cert.pem</string>
+    <key>CA_KEY_FILE</key><string>/etc/ai-proxy/ca-key.pem</string>
+    <key>ENABLED_PACKS</key><string>SECRETS,GLOBAL,DE</string>
+    <key>USE_AI_DETECTION</key><string>false</string>
+    <key>LOG_LEVEL</key><string>info</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key><false/>
+  </dict>
+  <key>StandardOutPath</key><string>/var/log/ai-proxy/stdout.log</string>
+  <key>StandardErrorPath</key><string>/var/log/ai-proxy/stderr.log</string>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>

--- a/packaging/macos/pkg/distribution.xml
+++ b/packaging/macos/pkg/distribution.xml
@@ -19,6 +19,6 @@
     <pkg-ref id="com.ai-anonymizing-proxy.pkg"/>
   </choice>
   <pkg-ref id="com.ai-anonymizing-proxy.pkg"
-           version="0"
+           version="__PKG_VERSION__"
            onConclusion="none">ai-proxy-component.pkg</pkg-ref>
 </installer-gui-script>

--- a/packaging/macos/pkg/distribution.xml
+++ b/packaging/macos/pkg/distribution.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+  <title>AI Anonymizing Proxy</title>
+  <organization>com.ai-anonymizing-proxy</organization>
+  <domains enable_anywhere="true" enable_currentUserHome="false" enable_localSystem="true"/>
+  <options customize="never" require-scripts="true" rootVolumeOnly="true"/>
+  <volume-check>
+    <allowed-os-versions>
+      <os-version min="12.0"/>
+    </allowed-os-versions>
+  </volume-check>
+  <choices-outline>
+    <line choice="default">
+      <line choice="com.ai-anonymizing-proxy.pkg"/>
+    </line>
+  </choices-outline>
+  <choice id="default"/>
+  <choice id="com.ai-anonymizing-proxy.pkg" visible="false">
+    <pkg-ref id="com.ai-anonymizing-proxy.pkg"/>
+  </choice>
+  <pkg-ref id="com.ai-anonymizing-proxy.pkg"
+           version="0"
+           onConclusion="none">ai-proxy-component.pkg</pkg-ref>
+</installer-gui-script>

--- a/packaging/macos/pkg/notarize.sh
+++ b/packaging/macos/pkg/notarize.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Submit a signed .pkg for Apple notarization, then staple the ticket.
+# Stapling is what lets the package install offline — without it, every install
+# host has to call out to Apple to verify the notarization status.
+#
+# Required env vars:
+#   PKG_PATH        — path to the signed .pkg
+#   NOTARY_PROFILE  — name of a keychain profile previously created via
+#                     `xcrun notarytool store-credentials`
+
+: "${PKG_PATH:?PKG_PATH required}"
+: "${NOTARY_PROFILE:?NOTARY_PROFILE required (created via 'notarytool store-credentials')}"
+
+xcrun notarytool submit "$PKG_PATH" \
+  --keychain-profile "$NOTARY_PROFILE" \
+  --wait
+
+xcrun stapler staple "$PKG_PATH"
+xcrun stapler validate "$PKG_PATH"
+spctl --assess --type install --verbose=2 "$PKG_PATH"
+
+echo "Notarized + stapled: $PKG_PATH"

--- a/packaging/macos/pkg/proxy-config.json.default
+++ b/packaging/macos/pkg/proxy-config.json.default
@@ -1,0 +1,12 @@
+{
+  "proxyPort": 18080,
+  "managementPort": 18081,
+  "bindAddress": "127.0.0.1",
+  "useAIDetection": false,
+  "logLevel": "info",
+  "caCertFile": "/etc/ai-proxy/ca-cert.pem",
+  "caKeyFile": "/etc/ai-proxy/ca-key.pem",
+  "ollamaCacheFile": "/var/lib/ai-proxy/ollama-cache.db",
+  "enabledPacks": ["SECRETS", "GLOBAL", "DE"],
+  "packDecayRate": 0.05
+}

--- a/packaging/macos/pkg/scripts/postinstall
+++ b/packaging/macos/pkg/scripts/postinstall
@@ -48,12 +48,27 @@ fi
 rollback_ca_trust() {
   # See linux postinstall.sh — same rationale: trusted CA without a running
   # interceptor is the failure mode that lets PII flow out unanonymized.
+  # Exit code MUST reflect actual System keychain state, not intent: if the
+  # delete fails or the cert is still trusted after, the caller (and the
+  # operator) must see a distinct failure, not a successful-rollback signal.
   SHA=$(/usr/bin/openssl x509 -in /etc/ai-proxy/ca-cert.pem -noout -fingerprint -sha1 2>/dev/null \
         | sed 's/.*=//; s/://g' || true)
-  if [ -n "$SHA" ]; then
-    /usr/bin/security delete-certificate -Z "$SHA" /Library/Keychains/System.keychain >/dev/null 2>&1 || true
-    echo "ai-proxy: CA removed from System keychain to prevent trust-without-interception." >&2
+  if [ -z "$SHA" ]; then
+    echo "ai-proxy: ROLLBACK FAILED — could not compute CA fingerprint to delete." >&2
+    echo "ai-proxy:   manual remediation: 'sudo security delete-certificate -c \"ai-proxy CA\" /Library/Keychains/System.keychain'" >&2
+    return 1
   fi
+  /usr/bin/security delete-certificate -Z "$SHA" /Library/Keychains/System.keychain >/dev/null 2>&1
+  # Verify the cert is actually gone — delete-certificate exit code alone is
+  # insufficient (it returns 0 even when the cert never existed).
+  if /usr/bin/security find-certificate -Z "$SHA" /Library/Keychains/System.keychain >/dev/null 2>&1; then
+    echo "ai-proxy: ROLLBACK FAILED — CA $SHA still trusted in System keychain after delete attempt." >&2
+    echo "ai-proxy:   PII MAY LEAK. Manual remediation required:" >&2
+    echo "ai-proxy:     sudo security delete-certificate -Z $SHA /Library/Keychains/System.keychain" >&2
+    return 1
+  fi
+  echo "ai-proxy: CA $SHA removed from System keychain (trust-without-interception averted)." >&2
+  return 0
 }
 
 # Trust the CA in the System keychain.
@@ -66,11 +81,23 @@ if [ -f /etc/ai-proxy/ca-cert.pem ]; then
     /etc/ai-proxy/ca-cert.pem
 fi
 
-# Bootstrap the LaunchDaemon.
-if ! /bin/launchctl bootstrap system /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>/dev/null; then
-  if ! /bin/launchctl load -w /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>/dev/null; then
-    echo "ai-proxy postinstall: failed to load LaunchDaemon. Rolling back CA trust." >&2
-    rollback_ca_trust
+# Bootstrap the LaunchDaemon. Capture stderr so the diagnostic survives the
+# fallback path — silencing it would lose the actual error.
+bootstrap_err=$(/bin/launchctl bootstrap system \
+  /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>&1) || bootstrap_rc=$?
+if [ "${bootstrap_rc:-0}" -ne 0 ]; then
+  load_err=$(/bin/launchctl load -w \
+    /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>&1) || load_rc=$?
+  if [ "${load_rc:-0}" -ne 0 ]; then
+    echo "ai-proxy postinstall: LaunchDaemon failed to load." >&2
+    echo "ai-proxy:   launchctl bootstrap: $bootstrap_err" >&2
+    echo "ai-proxy:   launchctl load -w:   $load_err" >&2
+    echo "ai-proxy: rolling back CA trust to avoid trust-without-interception." >&2
+    if ! rollback_ca_trust; then
+      # Rollback itself failed — exit with a distinct code so the operator can
+      # tell "service down, CA cleaned" (1) from "service down, CA STILL TRUSTED" (2).
+      exit 2
+    fi
     exit 1
   fi
 fi

--- a/packaging/macos/pkg/scripts/postinstall
+++ b/packaging/macos/pkg/scripts/postinstall
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -eu
+
+# Allocate UID/GID for the _aiproxy service account if absent.
+# Pick the lowest free UID in the 220-400 macOS system-user range.
+if ! dscl . -read /Users/_aiproxy UniqueID >/dev/null 2>&1; then
+  uid=""
+  for candidate in $(seq 220 400); do
+    if ! dscl . -search /Users UniqueID "$candidate" 2>/dev/null | grep -q .; then
+      uid="$candidate"
+      break
+    fi
+  done
+  if [ -z "$uid" ]; then
+    echo "ai-proxy postinstall: no free UID in 220-400; allocate _aiproxy manually." >&2
+    exit 1
+  fi
+
+  dscl . -create /Groups/_aiproxy
+  dscl . -create /Groups/_aiproxy PrimaryGroupID "$uid"
+  dscl . -create /Groups/_aiproxy RealName "AI Proxy Service"
+  dscl . -create /Groups/_aiproxy Password "*"
+
+  dscl . -create /Users/_aiproxy
+  dscl . -create /Users/_aiproxy UniqueID "$uid"
+  dscl . -create /Users/_aiproxy PrimaryGroupID "$uid"
+  dscl . -create /Users/_aiproxy NFSHomeDirectory /var/empty
+  dscl . -create /Users/_aiproxy UserShell /usr/bin/false
+  dscl . -create /Users/_aiproxy RealName "AI Proxy Service"
+  dscl . -create /Users/_aiproxy IsHidden 1
+  dscl . -create /Users/_aiproxy Password "*"
+fi
+
+install -d -m 0755 /etc/ai-proxy
+install -d -m 0750 -o _aiproxy -g _aiproxy /var/lib/ai-proxy
+install -d -m 0755 -o _aiproxy -g _aiproxy /var/log/ai-proxy
+
+# Generate CA if absent (idempotent; preserves user CA on upgrade).
+if [ ! -f /etc/ai-proxy/ca-cert.pem ] || [ ! -f /etc/ai-proxy/ca-key.pem ]; then
+  /usr/local/bin/ai-proxy --generate-ca \
+    --ca-cert /etc/ai-proxy/ca-cert.pem \
+    --ca-key /etc/ai-proxy/ca-key.pem
+  chmod 0644 /etc/ai-proxy/ca-cert.pem
+  chmod 0640 /etc/ai-proxy/ca-key.pem
+  chown _aiproxy:_aiproxy /etc/ai-proxy/ca-key.pem
+fi
+
+rollback_ca_trust() {
+  # See linux postinstall.sh — same rationale: trusted CA without a running
+  # interceptor is the failure mode that lets PII flow out unanonymized.
+  SHA=$(/usr/bin/openssl x509 -in /etc/ai-proxy/ca-cert.pem -noout -fingerprint -sha1 2>/dev/null \
+        | sed 's/.*=//; s/://g' || true)
+  if [ -n "$SHA" ]; then
+    /usr/bin/security delete-certificate -Z "$SHA" /Library/Keychains/System.keychain >/dev/null 2>&1 || true
+    echo "ai-proxy: CA removed from System keychain to prevent trust-without-interception." >&2
+  fi
+}
+
+# Trust the CA in the System keychain.
+if [ -f /etc/ai-proxy/ca-cert.pem ]; then
+  /usr/bin/security add-trusted-cert -d -r trustRoot \
+    -k /Library/Keychains/System.keychain \
+    /etc/ai-proxy/ca-cert.pem >/dev/null 2>&1 || \
+  /usr/bin/security add-trusted-cert -d -r trustRoot \
+    -k /Library/Keychains/System.keychain \
+    /etc/ai-proxy/ca-cert.pem
+fi
+
+# Bootstrap the LaunchDaemon.
+if ! /bin/launchctl bootstrap system /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>/dev/null; then
+  if ! /bin/launchctl load -w /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>/dev/null; then
+    echo "ai-proxy postinstall: failed to load LaunchDaemon. Rolling back CA trust." >&2
+    rollback_ca_trust
+    exit 1
+  fi
+fi
+
+exit 0

--- a/packaging/macos/pkg/scripts/preuninstall
+++ b/packaging/macos/pkg/scripts/preuninstall
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eu
+
+# pkgbuild has no native uninstall hook on macOS. This script ships at
+# /usr/local/share/ai-proxy/uninstall.sh and is also wired as the component
+# preuninstall script for future installer hooks that may invoke it.
+
+# Stop the daemon.
+/bin/launchctl bootout system/com.ai-anonymizing-proxy 2>/dev/null || \
+  /bin/launchctl unload /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist 2>/dev/null || true
+
+# Remove CA from System keychain.
+if [ -f /etc/ai-proxy/ca-cert.pem ]; then
+  SHA=$(/usr/bin/openssl x509 -in /etc/ai-proxy/ca-cert.pem -noout -fingerprint -sha1 \
+        | sed 's/.*=//; s/://g')
+  /usr/bin/security delete-certificate -Z "$SHA" /Library/Keychains/System.keychain 2>/dev/null || true
+fi
+
+# Remove the LaunchDaemon plist.
+rm -f /Library/LaunchDaemons/com.ai-anonymizing-proxy.plist
+
+# User data under /etc/ai-proxy is preserved — admin's call to remove.
+echo "ai-proxy: service stopped and CA trust removed."
+echo "ai-proxy: /etc/ai-proxy preserved. Run 'sudo rm -rf /etc/ai-proxy' to purge config."
+echo "ai-proxy: forget the package receipt with 'sudo pkgutil --forget com.ai-anonymizing-proxy.pkg'"
+
+exit 0


### PR DESCRIPTION
Phase 2 of the UEM packaging workstream — macOS PKG installer (signed + notarized + stapled on tag builds) and a JAMF-deployable `.mobileconfig` profile.

## What ships

- `packaging/macos/pkg/` — `build.sh`, `distribution.xml`, `scripts/postinstall`, `scripts/preuninstall`, `notarize.sh`, the in-package LaunchDaemon plist, the conffile defaults. `build.sh` and `mobileconfig/build.sh` both honor `SKIP_SIGN=1` for the PR-event dry-run path.
- LaunchDaemon at `/Library/LaunchDaemons/com.ai-anonymizing-proxy.plist`, `RunAtLoad=true`, `KeepAlive={SuccessfulExit=false}`
- `_aiproxy` system user created in postinstall (UID auto-allocated 220–400, hidden, no shell)
- CA injection into `/Library/Keychains/System.keychain`. **Postinstall rollback verifies actual keychain state** and exits with distinct codes — `1` = "service down, CA cleaned", `2` = "service down, CA STILL TRUSTED, manual remediation required" (H2).
- `packaging/macos/mobileconfig/ai-proxy.mobileconfig.tmpl` + `build.sh` — CA trust + global HTTP proxy payloads, with **ExceptionsList** for `127.0.0.1`, `localhost`, `*.local`, `169.254/16` (M3).
- `make package-macos`, `make package-macos-pkg`, `make package-macos-mobileconfig` (refuse to run off Darwin)
- `.github/workflows/release-macos-pkg.yml`:
  - **PR runs** do a `Validate build mechanism (PR dry-run, no signing)` step (N1).
  - **Tag runs** execute the full sign + notarize + staple + upload path.
  - P12 cleanup via `trap EXIT` (H5). Explicit artifact upload list (H6). `concurrency:` block (L2). YAML comment above `Notarize PKG` references issue #125 (H3).
- `docs/packaging/macos.md` — install / configure / verify / upgrade / uninstall, blast-radius callout (H7), per-route rotation (M4), troubleshooting (L3), pre-tag verification ritual (H3).
- Issue #125 — pre-tag MDM-host HTTPS-interception verification ritual.

## Quality Gates

- [x] `make check` passed locally on `8e5c975`. lint: `0 issues.` / test: all 10 `ok` / security: `Issues : 0` / vulncheck: `No vulnerabilities found.`
- [x] `go test -race ./...` passed on `8e5c975` — every package `ok`, no `--- FAIL`.
- [x] Coverage minimums met (table below). 95%+ on anonymizer / config / packs; 94.4% total.
- [x] Delta coverage ≥90% — N/A by gate (zero `.go` files in PR diff; script skip is documented behavior).
- [x] [§6 Test Inventory baseline-vs-head](#6-test-inventory--baseline-vs-head) completed.
- [x] No hacks — diff grep at head returns empty for `TODO|FIXME|HACK|XXX|//nolint|t\.Skip|coverage-ignore`.
- [x] All CI jobs green at the PR head SHA `8e5c975`.

### Coverage (per Go package)

| Package | Coverage | Gate |
|---|---|---|
| `./cmd/proxy/` | 100.0% | — |
| `./internal/anonymizer/` | 95.6% | ≥95% ✅ |
| `./internal/anonymizer/packs/` | 97.6% | ≥95% ✅ |
| `./internal/config/` | 100.0% | ≥95% ✅ |
| `./internal/domainmatch/` | 100.0% | — |
| `./internal/logger/` | 86.4% | — |
| `./internal/management/` | 89.8% | — |
| `./internal/metrics/` | 100.0% | — |
| `./internal/mitm/` | 85.7% | — |
| `./internal/proxy/` | 93.0% | — |
| **total** | **94.4%** | ≥85% ✅ |

## Delta Coverage Report

```bash
go test -race -coverprofile=coverage.out -covermode=atomic ./...
bash .github/scripts/delta-coverage.sh coverage.out 90.0 origin/main
```

Output:
```text
No changed Go source files — delta coverage check skipped.
```

PR diff contains zero `.go` files (`git diff --name-only --diff-filter=ACMR origin/main...HEAD -- '*.go'` is empty). The script's documented behavior on empty Go diffs is to skip with exit 0.

## §6 Test Inventory — baseline vs head

**Method per `docs/test-plans/ai-proxy-test-method.md`:**
1. Spec source: §6 table, organized **per PII pack**, mapping each pack to its unit test file and (where present) report test file.
2. For each row, extracted top-level test names from the named file(s) with `grep -oE '^func (Test[A-Za-z0-9_]+)'`, passed them to `go test -race -count=1 -v -run "^(N1|N2|...)$" <pkg>`.
3. Counted `--- PASS` and `--- FAIL` lines **top-level + subtests** per CLAUDE.md gate spec — `grep -cE '^[[:space:]]*--- PASS'` (the leading-whitespace match captures indented subtest results, which the prior round's `^--- PASS` missed; **all previously-posted numbers were undercounted**).
4. Two independent worktrees (`git worktree add /tmp/main-tree 6436ce0` and the PR head), separate `go test` invocations against separate trees. Not derived from `git diff`.

| §6 row | File(s) | main (`6436ce0`) PASS / FAIL | head (`8e5c975`) PASS / FAIL | Δ |
|---|---|---|---|---|
| GLOBAL | `packs/global_test.go` | 22 / 0 | 22 / 0 | 0 |
| DE | `packs/de_test.go` | 17 / 0 | 17 / 0 | 0 |
| US | `packs/us_test.go` | 38 / 0 | 38 / 0 | 0 |
| FR | `packs/fr_test.go` | 41 / 0 | 41 / 0 | 0 |
| SECRETS (unit) | `packs/secrets_test.go` | 28 / 0 | 28 / 0 | 0 |
| SECRETS (report) | `anonymizer/secrets_report_test.go` | 44 / 0 | 44 / 0 | 0 |
| NL (unit) | `packs/nl_test.go` | 12 / 0 | 12 / 0 | 0 |
| NL (report) | `anonymizer/nl_report_test.go` | 6 / 0 | 6 / 0 | 0 |
| FINANCE_EU (unit) | `packs/finance_eu_test.go` | 15 / 0 | 15 / 0 | 0 |
| FINANCE_EU (report) | `anonymizer/finance_eu_report_test.go` | 12 / 0 | 12 / 0 | 0 |
| HEALTHCARE (unit) | `packs/healthcare_test.go` | 4 / 0 | 4 / 0 | 0 |
| HEALTHCARE (report) | `anonymizer/healthcare_report_test.go` | 15 / 0 | 15 / 0 | 0 |
| Cross-pack (all report tests) | `anonymizer/{secrets,nl,finance_eu,healthcare,secrets_priority}_report_test.go` | 90 / 0 | 90 / 0 | 0 |

`diff /tmp/inv6-main.txt /tmp/inv6-head.txt` returns empty. Zero deltas on every row.

### §5 Known-issues pinning tests

The method's §5 names specific tests as pins for known issues. Each was executed independently by name on both worktrees:

| Pinning test | Issue | main (`6436ce0`) | head (`8e5c975`) | Δ |
|---|---|---|---|---|
| `TestDESteuerIDPattern` | #67 | 1 / 0 | 1 / 0 | 0 |
| `TestDESVNRPattern` | #67 | 1 / 0 | 1 / 0 | 0 |
| `TestUSAddressPattern` (German* subtests) | #68 | 7 / 0 | 7 / 0 | 0 |
| `TestSIREN_SSN_CrossPattern` | #69 | 4 / 0 | 4 / 0 | 0 |
| `TestFRSIRENPattern` | #69 | 1 / 0 | 1 / 0 | 0 |
| **`TestSecretsPriorityOverGLOBAL`** | **#70** | **12 / 0** | **12 / 0** | **0** |
| `TestNLKvKPattern` | (design) | 1 / 0 | 1 / 0 | 0 |
| `TestFINANCEEUSWIFTBICPattern` | (design) | 1 / 0 | 1 / 0 | 0 |
| `TestHEALTHCAREICD10Pattern` | (design) | 1 / 0 | 1 / 0 | 0 |
| `TestHEALTHCAREMRNPattern` | (design) | 1 / 0 | 1 / 0 | 0 |

Issue #70 / `TestSecretsPriorityOverGLOBAL` directly pins **CLAUDE.md Invariant #3** ("SECRETS must precede GLOBAL"). Verified PASS at head by name.

### §2.3 Report-test config compliance

Every report test under `internal/anonymizer/*_report_test.go` declares the canonical configuration the method requires:

```bash
grep -n "EnabledPacks" internal/anonymizer/*_report_test.go
```

Returns `EnabledPacks: []string{"SECRETS", "GLOBAL", "US", "DE", "FR", "NL", "FINANCE_EU", "HEALTHCARE"}` in every report test, with `UseAI: false` and `PackDecayRate: 0.0` adjacent. SECRETS precedes GLOBAL — Invariant #3 satisfied at the config level, in addition to the named-test pin above.

### Supplemental: per-Go-package rollup

| Package | main (`6436ce0`) | head (`8e5c975`) | Δ |
|---|---|---|---|
| `./cmd/proxy/` | 17 / 0 | 17 / 0 | 0 |
| `./internal/anonymizer/` | 202 / 0 | 202 / 0 | 0 |
| `./internal/anonymizer/packs/` | 71 / 0 | 71 / 0 | 0 |
| `./internal/config/` | 34 / 0 | 34 / 0 | 0 |
| `./internal/domainmatch/` | 5 / 0 | 5 / 0 | 0 |
| `./internal/logger/` | 11 / 0 | 11 / 0 | 0 |
| `./internal/management/` | 38 / 0 | 38 / 0 | 0 |
| `./internal/metrics/` | 17 / 0 | 17 / 0 | 0 |
| `./internal/mitm/` | 30 / 0 | 30 / 0 | 0 |
| `./internal/proxy/` | 59 / 0 | 59 / 0 | 0 |

Note: these per-package counts use `go test -v -count=1 ./<pkg>` (whole-package) with subtest-aware grep. They are a rollup, not the gate artifact — the §6 per-pack table above is the artifact the spec demands.

## Review-feedback resolution

| ID | Round | Fix |
|---|---|---|
| H1 | R1 | PR body disclosure + checklist filled. |
| H2 | R1 (`00d341a`) | postinstall rollback verifies cert is actually absent; distinct exit code 2 when CA STILL TRUSTED. |
| H3 | R1 → R2 reformulated | Trackable artifact triple: issue #125 + workflow YAML comment + docs § Pre-tag verification ritual. |
| H4 | R1 (`79c409b`) | Secret-verify + signing/notarize gated on `IS_RELEASE`. |
| H5 | R1 (`79c409b`) | P12 cleanup via `trap EXIT`. |
| H6 | R1 (`79c409b`) | Artifact upload explicit filenames. |
| H7 | R1 (`c219de1`) | Blast-radius callout in docs. |
| M1 | R1 (`b9ce7c6`) | macOS env file ports match plist. |
| M2 | R1 (`b9ce7c6`) | `distribution.xml` `pkg-ref version` rendered from `$VERSION`. |
| M3 | R1 (`b9ce7c6`) | `.mobileconfig` ExceptionsList. |
| M4 | R1 (`c219de1`) | Rotation per route. |
| L1 | R1 (`00d341a`) | bootstrap stderr captured. |
| L2 | R1 (`79c409b`) | concurrency block. |
| L3 | R1 (`c219de1`) | Troubleshooting section. |
| N1 | R2 (`274e319`) | PR-event dry-run exercises build mechanism. |
| Gate 5 §6 inventory | R3 | Per-pack execution; previously was per-Go-package. |
| Gate 5 subtest counting + §5 pins + §2.3 config | R4 | Subtest-aware grep (`^[[:space:]]*--- PASS`); §5 named-test pin table; §2.3 config compliance verified. |

## Verified

- `bash -n` clean on every shell script
- `xmllint --noout` clean on `distribution.xml`, the LaunchDaemon plist, and the `.mobileconfig.tmpl`
- YAML parse clean on the workflow
- JSON parse clean on `proxy-config.json.default`
- `make check` clean on `8e5c975`
- `go test -race ./...` clean on `8e5c975`
- §6 inventory: two independent worktree executions, per-pack, subtest-aware, zero deltas
- §5 known-issues pinning tests verified by name on both worktrees, zero deltas
- §2.3 report-test config compliance grep'd from source
- `make -n package-macos-pkg` gates on Darwin
- PR-event macOS CI: dry-run path exercises payload staging + pkgbuild + productbuild + mobileconfig render unsigned

**Pre-tag manual gate (issue #125):** `.mobileconfig` HTTPS-interception verification on MDM-enrolled host — required before pushing any `v*` tag.

## Out of scope

- Homebrew tap (Phase 5a)
- Windows MSI (Phase 3)
- Sparkle / auto-update integration
- JAMF policy templates wrapping the .mobileconfig (left to admins)

## Related

- Previous: Phase 1 Linux DEB/RPM (PR #120)
- Next: Phase 3 Windows MSI + ADMX
- Pre-tag gate: #125