### PR TITLE
chore: replace nolint:errcheck with explicit error handling (#102)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ai-anonymizing-proxy
 
-go 1.26.3
+go 1.26.4
 
 require (
 	go.etcd.io/bbolt v1.4.3

--- a/internal/anonymizer/anonymizer.go
+++ b/internal/anonymizer/anonymizer.go
@@ -738,7 +738,7 @@ Return ONLY the JSON array, no explanation. Example: [{"original":"John Smith","
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort close on HTTP response body
+	defer func() { _ = resp.Body.Close() }() // best-effort close on HTTP response body
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/anonymizer/anonymizer.go
+++ b/internal/anonymizer/anonymizer.go
@@ -82,6 +82,11 @@ const (
 // sseDataPrefix is the Server-Sent Events data field prefix ("data: ").
 const sseDataPrefix = "data: "
 
+// jsonMarshal is a seam over json.Marshal so tests can exercise the
+// AnonymizeJSON marshal-error fallback. A successful marshal of already-parsed
+// JSON never fails in practice, leaving that branch otherwise unreachable.
+var jsonMarshal = json.Marshal
+
 // pattern pairs a compiled regex with its PII type and a base confidence score.
 // Confidence reflects how specifically the regex identifies the target PII type:
 // high scores mean low false-positive risk; low scores indicate ambiguous patterns
@@ -461,7 +466,7 @@ func (a *Anonymizer) AnonymizeJSON(body []byte, requestID string) []byte {
 		}
 	}
 
-	out, err := json.Marshal(anonymized)
+	out, err := jsonMarshal(anonymized)
 	if err != nil {
 		return body // fallback: return original
 	}

--- a/internal/anonymizer/anonymizer_coverage_test.go
+++ b/internal/anonymizer/anonymizer_coverage_test.go
@@ -2,6 +2,7 @@ package anonymizer
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -10,12 +11,20 @@ import (
 // is included alongside a real one ("GLOBAL"); the bogus name hits the
 // len(entries)==0 branch while the real pack still loads patterns.
 func TestLoadPacksUnknownPackWarning(t *testing.T) {
+	logs := captureLog(t)
 	a := NewWithCacheAndCapacity(Options{
 		OllamaEndpoint: "http://localhost:11434",
 		OllamaModel:    "test-model",
 		EnabledPacks:   []string{"NONEXISTENT_PACK_XYZ", "GLOBAL"},
 	})
 	defer func() { _ = a.Close() }() // test cleanup
+
+	// Pin the warning branch: only the len(entries)==0 path logs this for the
+	// bogus pack. Successful loading of GLOBAL (asserted below) would still hold
+	// if that branch were removed, so it is not branch-specific on its own.
+	if !strings.Contains(logs.String(), `enabled pack "NONEXISTENT_PACK_XYZ" has no registered patterns`) {
+		t.Errorf("expected unknown-pack warning log, got: %q", logs.String())
+	}
 
 	if a == nil {
 		t.Fatal("expected non-nil anonymizer despite unknown pack")

--- a/internal/anonymizer/anonymizer_coverage_test.go
+++ b/internal/anonymizer/anonymizer_coverage_test.go
@@ -1,0 +1,51 @@
+package anonymizer
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestLoadPacksUnknownPackWarning covers the warning branch in loadPacks that
+// fires when an enabled pack name has no registered patterns. A bogus pack name
+// is included alongside a real one ("GLOBAL"); the bogus name hits the
+// len(entries)==0 branch while the real pack still loads patterns.
+func TestLoadPacksUnknownPackWarning(t *testing.T) {
+	a := NewWithCacheAndCapacity(Options{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test-model",
+		EnabledPacks:   []string{"NONEXISTENT_PACK_XYZ", "GLOBAL"},
+	})
+	defer func() { _ = a.Close() }() // test cleanup
+
+	if a == nil {
+		t.Fatal("expected non-nil anonymizer despite unknown pack")
+	}
+	if len(a.patterns) == 0 {
+		t.Fatal("expected patterns loaded from the real GLOBAL pack")
+	}
+
+	// The anonymizer must still anonymize using the real pack's patterns.
+	result := a.AnonymizeText("Contact alice@example.com", "sess-loadpacks")
+	if result == "Contact alice@example.com" {
+		t.Error("anonymization failed with a mix of unknown and real packs")
+	}
+}
+
+// TestAnonymizeJSONMarshalErrorFallback covers the marshal-error fallback in
+// AnonymizeJSON via the jsonMarshal seam. When marshaling fails, AnonymizeJSON
+// must return the original body bytes unchanged.
+func TestAnonymizeJSONMarshalErrorFallback(t *testing.T) {
+	orig := jsonMarshal
+	defer func() { jsonMarshal = orig }()
+	jsonMarshal = func(any) ([]byte, error) { return nil, errors.New("boom") }
+
+	a := newTestAnonymizer()
+	defer func() { _ = a.Close() }() // test cleanup
+
+	body := []byte(`{"messages":[{"role":"user","content":"hi alice@example.com"}]}`)
+	got := a.AnonymizeJSON(body, "req-1")
+
+	if string(got) != string(body) {
+		t.Errorf("expected original body on marshal error, got: %q", got)
+	}
+}

--- a/internal/anonymizer/anonymizer_test.go
+++ b/internal/anonymizer/anonymizer_test.go
@@ -5,13 +5,29 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"ai-anonymizing-proxy/internal/anonymizer/packs"
 	"ai-anonymizing-proxy/internal/metrics"
 )
+
+// waitUntil polls cond on real time until it is true or a generous deadline
+// elapses. Async Ollama dispatch goroutines block on network I/O or scheduling,
+// so a bounded runtime.Gosched() spin can exhaust before they complete (causing
+// flaky failures and coverage dips on contended runners); a real-time deadline
+// with sleeps is robust. Returns whether cond became true.
+func waitUntil(cond func() bool) bool {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return cond()
+}
 
 func newTestAnonymizer() *Anonymizer {
 	return New("http://localhost:11434", "test-model", false, 0.8, 1, nil)
@@ -868,14 +884,12 @@ func TestDispatchOllamaAsyncSemaphoreFull(t *testing.T) {
 	a.dispatchOllamaAsync("test-value")
 
 	// Wait for inflight to clear — this means the goroutine has completed.
-	for range 10000 {
-		runtime.Gosched()
+	if !waitUntil(func() bool {
 		a.inflightMu.Lock()
-		done := !a.inflight["test-value"]
-		a.inflightMu.Unlock()
-		if done {
-			break
-		}
+		defer a.inflightMu.Unlock()
+		return !a.inflight["test-value"]
+	}) {
+		t.Fatal("dispatch goroutine did not finish in time")
 	}
 
 	// Now drain semaphore (it was never consumed by the goroutine).
@@ -1347,19 +1361,13 @@ func TestDispatchOllamaAsyncWithMockServer(t *testing.T) {
 
 	a.dispatchOllamaAsync("test@example.com")
 
-	// Wait for the goroutine to complete.
-	for range 10000 {
-		runtime.Gosched()
-		a.inflightMu.Lock()
-		done := !a.inflight["test@example.com"]
-		a.inflightMu.Unlock()
-		if done {
-			break
-		}
-	}
-
-	// The cache should now have an entry.
-	_, hit := a.cache.Get("test@example.com")
+	// Wait (on real time) for the goroutine's HTTP round-trip to finish and
+	// populate the cache. The inflight-clearing defer runs after cache.Set, so a
+	// cache hit is the definitive completion signal.
+	hit := waitUntil(func() bool {
+		_, ok := a.cache.Get("test@example.com")
+		return ok
+	})
 	if !hit {
 		t.Error("expected cache entry after successful Ollama dispatch")
 	}

--- a/internal/anonymizer/anonymizer_test.go
+++ b/internal/anonymizer/anonymizer_test.go
@@ -103,7 +103,7 @@ func TestStreamingDeanonymizeRoundTrip(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(anonymized))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = rc.Close() }() // test cleanup
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestStreamingDeanonymizeNoTokens(t *testing.T) {
 	src := io.NopCloser(strings.NewReader(text))
 	// session with no replacements: should get back the original reader unchanged
 	rc := a.StreamingDeanonymize(src, "empty-session", "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = rc.Close() }() // test cleanup
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -671,7 +671,7 @@ func TestStreamingDeanonymizeChunkBoundary(t *testing.T) {
 	// token split across chunk boundaries.
 	src := &bytewiseReader{data: []byte(anonymized)}
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = rc.Close() }() // test cleanup
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -799,7 +799,7 @@ func TestNewWithCacheAndCapacityBboltS3FIFO(t *testing.T) {
 		CachePath:           dir + "/test.db",
 		CacheCapacity:       100,
 	})
-	defer a.Close() //nolint:errcheck
+	defer func() { _ = a.Close() }()
 
 	// Verify the cache works through the S3FIFO layer.
 	a.cache.Set("test@example.com", "[PII_EMAIL_test1234]")
@@ -826,7 +826,7 @@ func TestNewWithCacheAndCapacityBboltBare(t *testing.T) {
 		CachePath:           dir + "/bare.db",
 		CacheCapacity:       0,
 	})
-	defer a.Close() //nolint:errcheck
+	defer func() { _ = a.Close() }()
 
 	a.cache.Set("val", "tok")
 	tok, ok := a.cache.Get("val")
@@ -946,7 +946,7 @@ func TestQueryOllamaHTTPSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := `{"response":"[{\"original\":\"alice@example.com\",\"type\":\"email\",\"confidence\":0.95}]"}`
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(resp)) //nolint:errcheck
+		_, _ = w.Write([]byte(resp))
 	}))
 	defer srv.Close()
 
@@ -975,7 +975,7 @@ func TestQueryOllamaHTTPSuccess(t *testing.T) {
 // TestQueryOllamaHTTPBadJSON covers the response parse error path.
 func TestQueryOllamaHTTPBadJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte(`not json`)) //nolint:errcheck
+		_, _ = w.Write([]byte(`not json`))
 	}))
 	defer srv.Close()
 
@@ -999,7 +999,7 @@ func TestQueryOllamaHTTPNoArray(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := `{"response":"I found no PII in this text."}`
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(resp)) //nolint:errcheck
+		_, _ = w.Write([]byte(resp))
 	}))
 	defer srv.Close()
 
@@ -1023,7 +1023,7 @@ func TestQueryOllamaHTTPBadArrayJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := `{"response":"[{bad json}]"}`
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(resp)) //nolint:errcheck
+		_, _ = w.Write([]byte(resp))
 	}))
 	defer srv.Close()
 
@@ -1244,8 +1244,8 @@ func TestStreamingDeanonymizeWithMetrics(t *testing.T) {
 	sseInput := "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n"
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck
-	io.ReadAll(rc)   //nolint:errcheck
+	defer func() { _ = rc.Close() }()
+	_, _ = io.ReadAll(rc)
 
 	if m.TokensDeanonymized.Load() == 0 {
 		t.Error("expected TokensDeanonymized > 0 with metrics")
@@ -1287,7 +1287,7 @@ func TestQueryOllamaHTTPReadBodyError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Set content length to force ReadAll to expect more data, then close.
 		w.Header().Set("Content-Length", "999999")
-		w.Write([]byte(`{"partial`)) //nolint:errcheck
+		_, _ = w.Write([]byte(`{"partial`))
 	}))
 	defer srv.Close()
 
@@ -1330,7 +1330,7 @@ func TestDispatchOllamaAsyncWithMockServer(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := `{"response":"[{\"original\":\"test@example.com\",\"type\":\"email\",\"confidence\":0.95}]"}`
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(resp)) //nolint:errcheck
+		_, _ = w.Write([]byte(resp))
 	}))
 	defer srv.Close()
 
@@ -1457,7 +1457,7 @@ func TestAnonymizeTextGermanNoFalseAddress(t *testing.T) {
 		EnabledPacks:        []string{"US"},
 		PackDecayRate:       0.0,
 	})
-	defer a.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = a.Close() }() // test cleanup
 
 	// Use digit strings that won't trigger the ZIP code pattern (which also
 	// produces PII_ADDRESS tokens for 5-digit sequences). The bug is about
@@ -1500,7 +1500,7 @@ func TestBboltCacheGetMiss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	token, ok := c.Get("nonexistent-key")
 	if ok || token != "" {
@@ -1515,7 +1515,7 @@ func TestBboltCacheOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	c.Set("key", "token1")
 	c.Set("key", "token2")
@@ -1532,7 +1532,7 @@ func TestBboltCacheDeleteMissing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Should not panic.
 	c.Delete("never-set-key")

--- a/internal/anonymizer/cache.go
+++ b/internal/anonymizer/cache.go
@@ -99,7 +99,7 @@ func newBboltCache(path string) (PersistentCache, error) {
 		_, err := tx.CreateBucketIfNotExists([]byte(bboltBucket))
 		return err
 	}); err != nil {
-		db.Close() //nolint:errcheck // best-effort close on init failure
+		_ = db.Close() // best-effort close on init failure
 		return nil, fmt.Errorf("create bbolt bucket: %w", err)
 	}
 

--- a/internal/anonymizer/cache.go
+++ b/internal/anonymizer/cache.go
@@ -77,7 +77,9 @@ func (c *memoryCache) Close() error { return nil }
 
 // --- bboltCache ----------------------------------------------------------
 
-const bboltBucket = "ollama_cache"
+// bboltBucket is a var (not const) so tests can temporarily set it to an
+// invalid value, exercising the bucket-creation error path in newBboltCache.
+var bboltBucket = "ollama_cache"
 
 // bboltCache is a PersistentCache backed by an embedded bbolt database.
 // Entries survive process restarts. The database file is created at the

--- a/internal/anonymizer/cache_error_test.go
+++ b/internal/anonymizer/cache_error_test.go
@@ -82,9 +82,14 @@ func TestBboltCacheClosedDBPaths(t *testing.T) {
 
 	logs := captureLog(t)
 
-	// Get on a closed db: db.View returns an error → ("", false).
+	// Get on a closed db: db.View returns an error which Get logs before
+	// returning ("", false). Assert the log to pin the error branch — an empty
+	// cache also returns ("", false), so the miss result alone proves nothing.
 	if v, found := bc.Get("k"); found || v != "" {
 		t.Errorf("expected miss on closed db, got v=%q found=%v", v, found)
+	}
+	if !strings.Contains(logs.String(), "bbolt Get error") {
+		t.Errorf("expected Get closed-db branch to log an error, got: %q", logs.String())
 	}
 
 	// Delete on a closed db: db.Update returns an error which Delete logs.

--- a/internal/anonymizer/cache_error_test.go
+++ b/internal/anonymizer/cache_error_test.go
@@ -38,20 +38,31 @@ func TestBboltCacheNilBucketPaths(t *testing.T) {
 	c := &bboltCache{db: db}
 	defer func() { _ = c.Close() }() // test cleanup
 
+	logs := captureLog(t)
+
 	// Get with a nil bucket returns ("", false).
 	if v, ok := c.Get("k"); ok || v != "" {
 		t.Errorf("expected miss on nil bucket, got v=%q ok=%v", v, ok)
 	}
 
-	// Set with a nil bucket logs an error and is a no-op (covers Set's nil-bucket
-	// branch and the error-log path).
+	// Set with a nil bucket takes the nil-bucket branch, which returns an error
+	// that Set logs. Assert the log to pin that branch (the no-persist check
+	// below is satisfied by Get's own nil-bucket path regardless of Set).
 	c.Set("k", "v")
+	if !strings.Contains(logs.String(), "bbolt Set error") {
+		t.Errorf("expected Set nil-bucket branch to log an error, got: %q", logs.String())
+	}
 	if v, ok := c.Get("k"); ok || v != "" {
 		t.Errorf("Set on nil bucket should not persist, got v=%q ok=%v", v, ok)
 	}
 
-	// Delete with a nil bucket is a no-op.
+	// Delete with a nil bucket is a silent no-op: the nil-bucket guard returns
+	// nil before touching b, so it must neither panic nor log an error. (If the
+	// guard were dropped, b.Delete on a nil bucket would panic and fail here.)
 	c.Delete("k")
+	if strings.Contains(logs.String(), "bbolt Delete error") {
+		t.Errorf("Delete on nil bucket should be a silent no-op, but logged: %q", logs.String())
+	}
 }
 
 // TestBboltCacheClosedDBPaths exercises the error branches of Get and Delete
@@ -69,11 +80,17 @@ func TestBboltCacheClosedDBPaths(t *testing.T) {
 		t.Fatalf("Close: %v", closeErr)
 	}
 
+	logs := captureLog(t)
+
 	// Get on a closed db: db.View returns an error → ("", false).
 	if v, found := bc.Get("k"); found || v != "" {
 		t.Errorf("expected miss on closed db, got v=%q found=%v", v, found)
 	}
 
-	// Delete on a closed db: db.Update returns an error → error log.
+	// Delete on a closed db: db.Update returns an error which Delete logs.
+	// Assert the log to pin the error branch (the call alone proves nothing).
 	bc.Delete("k")
+	if !strings.Contains(logs.String(), "bbolt Delete error") {
+		t.Errorf("expected Delete closed-db branch to log an error, got: %q", logs.String())
+	}
 }

--- a/internal/anonymizer/cache_error_test.go
+++ b/internal/anonymizer/cache_error_test.go
@@ -1,0 +1,79 @@
+package anonymizer
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// TestNewBboltCacheBucketError exercises the bucket-creation error path in
+// newBboltCache by temporarily setting bboltBucket to the empty string, which
+// makes CreateBucketIfNotExists return ErrBucketNameRequired.
+func TestNewBboltCacheBucketError(t *testing.T) {
+	orig := bboltBucket
+	defer func() { bboltBucket = orig }()
+	bboltBucket = ""
+
+	c, err := newBboltCache(filepath.Join(t.TempDir(), "x.db"))
+	if err == nil {
+		t.Fatal("expected error from empty bucket name, got nil")
+	}
+	if !strings.Contains(err.Error(), "create bbolt bucket") {
+		t.Errorf("expected 'create bbolt bucket' in error, got: %v", err)
+	}
+	if c != nil {
+		t.Errorf("expected nil cache on bucket error, got: %v", c)
+	}
+}
+
+// TestBboltCacheNilBucketPaths exercises the nil-bucket branches of Get, Set,
+// and Delete by constructing a bboltCache over a raw db that has no bucket.
+func TestBboltCacheNilBucketPaths(t *testing.T) {
+	db, err := bolt.Open(filepath.Join(t.TempDir(), "nobucket.db"), 0600, nil)
+	if err != nil {
+		t.Fatalf("bolt.Open: %v", err)
+	}
+	c := &bboltCache{db: db}
+	defer func() { _ = c.Close() }() // test cleanup
+
+	// Get with a nil bucket returns ("", false).
+	if v, ok := c.Get("k"); ok || v != "" {
+		t.Errorf("expected miss on nil bucket, got v=%q ok=%v", v, ok)
+	}
+
+	// Set with a nil bucket logs an error and is a no-op (covers Set's nil-bucket
+	// branch and the error-log path).
+	c.Set("k", "v")
+	if v, ok := c.Get("k"); ok || v != "" {
+		t.Errorf("Set on nil bucket should not persist, got v=%q ok=%v", v, ok)
+	}
+
+	// Delete with a nil bucket is a no-op.
+	c.Delete("k")
+}
+
+// TestBboltCacheClosedDBPaths exercises the error branches of Get and Delete
+// when the underlying db has been closed (db.View / db.Update return an error).
+func TestBboltCacheClosedDBPaths(t *testing.T) {
+	c, err := newBboltCache(filepath.Join(t.TempDir(), "closed.db"))
+	if err != nil {
+		t.Fatalf("newBboltCache: %v", err)
+	}
+	bc, ok := c.(*bboltCache)
+	if !ok {
+		t.Fatalf("expected *bboltCache, got %T", c)
+	}
+	if closeErr := bc.Close(); closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+
+	// Get on a closed db: db.View returns an error → ("", false).
+	if v, found := bc.Get("k"); found || v != "" {
+		t.Errorf("expected miss on closed db, got v=%q found=%v", v, found)
+	}
+
+	// Delete on a closed db: db.Update returns an error → error log.
+	bc.Delete("k")
+}

--- a/internal/anonymizer/cache_test.go
+++ b/internal/anonymizer/cache_test.go
@@ -10,7 +10,7 @@ import (
 // PersistentCache contract.
 func TestMemoryCacheBasicOperations(t *testing.T) {
 	c := newMemoryCache()
-	defer c.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = c.Close() }() // test cleanup
 
 	// Miss on empty cache.
 	if _, ok := c.Get("missing"); ok {
@@ -51,7 +51,7 @@ func TestBboltCacheBasicOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newBboltCache: %v", err)
 	}
-	defer c.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = c.Close() }() // test cleanup
 
 	// Miss on empty db.
 	if _, ok := c.Get("missing"); ok {
@@ -103,7 +103,7 @@ func TestBboltCacheSurvivesRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open second instance: %v", err)
 	}
-	defer c2.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = c2.Close() }() // test cleanup
 
 	token, ok := c2.Get("alice@example.com")
 	if !ok || token != "[PII_a3f29c81e4d07b56]" {
@@ -123,7 +123,7 @@ func TestNewWithCacheFallback(t *testing.T) {
 	if a == nil {
 		t.Fatal("expected non-nil anonymizer even with bad cache path")
 	}
-	defer a.Close() //nolint:errcheck // test cleanup
+	defer func() { _ = a.Close() }() // test cleanup
 
 	// Should still anonymize correctly using the fallback memory cache.
 	result := a.AnonymizeText("Contact alice@example.com", "sess-fallback")

--- a/internal/anonymizer/s3fifo_cache_test.go
+++ b/internal/anonymizer/s3fifo_cache_test.go
@@ -21,7 +21,7 @@ func newTestS3FIFO(capacity int) *s3fifoCache {
 func TestS3FIFOGetSetDelete(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Miss on empty cache.
 	if _, ok := c.Get("x"); ok {
@@ -58,7 +58,7 @@ func TestS3FIFOCapacityEnforced(t *testing.T) {
 	t.Parallel()
 	capacity := 10
 	c := newTestS3FIFO(capacity)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Fill to capacity with unique keys.
 	for i := 0; i < capacity+5; i++ {
@@ -82,7 +82,7 @@ func TestS3FIFOPromotionToM(t *testing.T) {
 	// S3-FIFO evicts only when total > capacity, so we need capacity+1 insertions
 	// to trigger eviction of the oldest S entry.
 	c := newTestS3FIFO(2)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Insert "hot" and access it so freq > 0.
 	c.Set("hot", "tok-hot")
@@ -113,7 +113,7 @@ func TestS3FIFOGhostBypassesS(t *testing.T) {
 	t.Parallel()
 	// capacity=2: eviction fires when total > 2.
 	c := newTestS3FIFO(2)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Insert "victim" (freq=0) and fill to capacity.
 	c.Set("victim", "tok-victim")
@@ -156,7 +156,7 @@ func TestS3FIFOGhostBounded(t *testing.T) {
 	t.Parallel()
 	// ghostCap = 2*sTarget = 2*(1) = 2, clamped to 4. Use capacity=20 → sTarget=2, ghostCap=4.
 	c := newTestS3FIFO(20)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	ghostCap := c.ghostCap
 
@@ -189,7 +189,7 @@ func TestS3FIFOColdReadRewarmsMemory(t *testing.T) {
 	if !ok {
 		t.Fatal("newS3FIFOCache did not return *s3fifoCache")
 	}
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Key is not in S3-FIFO memory yet.
 	c.mu.Lock()
@@ -219,7 +219,7 @@ func TestS3FIFOColdReadRewarmsMemory(t *testing.T) {
 func TestS3FIFOConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(100)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	const goroutines = 20
 	const ops = 200
@@ -263,7 +263,7 @@ func TestS3FIFOConcurrentAccess(t *testing.T) {
 func TestS3FIFOFrequencySaturation(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	c.Set("k", "v")
 	// Access many times; freq must saturate at 3.
@@ -291,7 +291,7 @@ func TestS3FIFOWithBboltBacking(t *testing.T) {
 	}
 
 	c := newS3FIFOCache(bbolt, 100)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	c.Set("persist@example.com", "[PII_feedbeef12345678]")
 
@@ -311,7 +311,7 @@ func TestS3FIFOWithBboltBacking(t *testing.T) {
 func TestS3FIFOGhostDedup(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(2) // capacity 2 → sTarget 1, ghostCap 4
-	defer c.Close()       //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Fill and evict to populate the ghost set.
 	c.Set("a", "t1")
@@ -334,7 +334,7 @@ func TestS3FIFOGhostDedup(t *testing.T) {
 func TestS3FIFOEvictFromSEmptyQueue(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Calling evictFromS on an empty S queue should be a no-op.
 	c.mu.Lock()
@@ -346,7 +346,7 @@ func TestS3FIFOEvictFromSEmptyQueue(t *testing.T) {
 func TestS3FIFOEvictFromMEmptyQueue(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Calling evictFromM on an empty M queue should be a no-op.
 	c.mu.Lock()
@@ -359,7 +359,7 @@ func TestS3FIFOEvictFromMEmptyQueue(t *testing.T) {
 func TestS3FIFOEvictFromSCorruptedElement(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Inject a corrupted (non-string) element into sQueue.
 	c.mu.Lock()
@@ -373,7 +373,7 @@ func TestS3FIFOEvictFromSCorruptedElement(t *testing.T) {
 func TestS3FIFOEvictFromMCorruptedElement(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Inject a corrupted (non-string) element into mQueue.
 	c.mu.Lock()
@@ -387,7 +387,7 @@ func TestS3FIFOEvictFromMCorruptedElement(t *testing.T) {
 func TestS3FIFOEvictFromSStaleEntry(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(10)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	c.Set("a", "t1")
 	c.Set("b", "t2")
@@ -408,7 +408,7 @@ func TestS3FIFONewWithZeroCapacity(t *testing.T) {
 	t.Parallel()
 	// Capacity 1 is the minimum — triggers sTarget=1, ghostCap=4 (min).
 	c := newTestS3FIFO(1)
-	defer c.Close() //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	c.Set("a", "t1")
 	c.Set("b", "t2") // triggers eviction
@@ -423,7 +423,7 @@ func TestS3FIFONewWithZeroCapacity(t *testing.T) {
 func TestS3FIFOEvictFromMPath(t *testing.T) {
 	t.Parallel()
 	c := newTestS3FIFO(2) // capacity 2, sTarget 1, mTarget 1
-	defer c.Close()       //nolint:errcheck
+	defer func() { _ = c.Close() }()
 
 	// Set a key and access it to bump freq, then overflow S to trigger promotion to M.
 	c.Set("a", "t1")

--- a/internal/anonymizer/streaming.go
+++ b/internal/anonymizer/streaming.go
@@ -44,10 +44,20 @@ func safeCutPoint(accumulated string) int {
 	return cutAt
 }
 
+// pipeWriter is the subset of *io.PipeWriter the streaming framework uses.
+// Abstracting it lets tests inject a writer whose CloseWithError returns a
+// non-nil error, exercising the failure-logging path that a real
+// *io.PipeWriter (CloseWithError always returns nil) cannot reach.
+type pipeWriter interface {
+	Write(p []byte) (int, error)
+	Close() error
+	CloseWithError(err error) error
+}
+
 // streamContext holds the mutable state shared by the streaming framework
 // functions during a single StreamingDeanonymize invocation.
 type streamContext struct {
-	pw       *io.PipeWriter
+	pw       pipeWriter
 	replacer *strings.Replacer
 	provider StreamingDeanonymizer
 }
@@ -55,7 +65,7 @@ type streamContext struct {
 // writePipe writes multiple byte slices to a PipeWriter, stopping on the
 // first error. A write error means the reader side has been closed (client
 // disconnected); continuing to write would be wasteful.
-func writePipe(pw *io.PipeWriter, parts ...[]byte) {
+func writePipe(pw pipeWriter, parts ...[]byte) {
 	for _, p := range parts {
 		if _, err := pw.Write(p); err != nil {
 			return

--- a/internal/anonymizer/streaming.go
+++ b/internal/anonymizer/streaming.go
@@ -68,23 +68,19 @@ func writePipe(pw *io.PipeWriter, parts ...[]byte) {
 // and passes through non-data lines with raw token replacement.
 func processLine(ctx *streamContext, line []byte) {
 	if len(line) == 0 || line[0] == ':' {
-		ctx.pw.Write(line)         //nolint:errcheck
-		ctx.pw.Write([]byte("\n")) //nolint:errcheck
+		writePipe(ctx.pw, line, []byte("\n"))
 		return
 	}
 
 	if !bytes.HasPrefix(line, []byte(sseDataPrefix)) {
-		ctx.pw.Write([]byte(ctx.replacer.Replace(string(line)))) //nolint:errcheck
-		ctx.pw.Write([]byte("\n"))                               //nolint:errcheck
+		writePipe(ctx.pw, []byte(ctx.replacer.Replace(string(line))), []byte("\n"))
 		return
 	}
 
 	payload := line[len(sseDataPrefix):]
 	if !ctx.provider.ProcessDataPayload(payload) {
 		// Provider could not parse the payload — fall back to raw replacement.
-		ctx.pw.Write([]byte(sseDataPrefix))                         //nolint:errcheck
-		ctx.pw.Write([]byte(ctx.replacer.Replace(string(payload)))) //nolint:errcheck
-		ctx.pw.Write([]byte("\n"))                                  //nolint:errcheck
+		writePipe(ctx.pw, []byte(sseDataPrefix), []byte(ctx.replacer.Replace(string(payload))), []byte("\n"))
 	}
 }
 
@@ -111,12 +107,14 @@ func assembleLines(chunk []byte, lineBuf []byte, ctx *streamContext) []byte {
 // text when the source reader returns an error (including io.EOF).
 func handleStreamEnd(lineBuf []byte, readErr error, ctx *streamContext) {
 	if len(lineBuf) > 0 {
-		ctx.pw.Write([]byte(ctx.replacer.Replace(string(lineBuf)))) //nolint:errcheck
+		writePipe(ctx.pw, []byte(ctx.replacer.Replace(string(lineBuf))))
 	}
 	ctx.provider.Flush()
 	if readErr != io.EOF {
 		log.Printf("[ANONYMIZER] StreamingDeanonymize read error: %v", readErr)
-		ctx.pw.CloseWithError(readErr) //nolint:errcheck
+		if err := ctx.pw.CloseWithError(readErr); err != nil {
+			log.Printf("[ANONYMIZER] StreamingDeanonymize CloseWithError failed: %v", err)
+		}
 	}
 }
 
@@ -124,8 +122,8 @@ func handleStreamEnd(lineBuf []byte, readErr error, ctx *streamContext) {
 // to processLine. At EOF it flushes any remaining partial line and
 // accumulated text via handleStreamEnd.
 func readLoop(src io.ReadCloser, ctx *streamContext) {
-	defer src.Close()    //nolint:errcheck
-	defer ctx.pw.Close() //nolint:errcheck
+	defer func() { _ = src.Close() }()
+	defer func() { _ = ctx.pw.Close() }()
 
 	var lineBuf []byte
 	const chunkSize = 32 * 1024

--- a/internal/anonymizer/streaming_cohere_test.go
+++ b/internal/anonymizer/streaming_cohere_test.go
@@ -210,7 +210,7 @@ func TestCohereStreamingVerboseLogging(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, cohereDomain)
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {

--- a/internal/anonymizer/streaming_error_test.go
+++ b/internal/anonymizer/streaming_error_test.go
@@ -1,0 +1,83 @@
+package anonymizer
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakePipeWriter is a pipeWriter whose Write/CloseWithError behavior is
+// configurable and which counts Write calls. It exercises the writePipe
+// early-return path and the inner failure-logging path in handleStreamEnd that
+// a real *io.PipeWriter (CloseWithError always returns nil) cannot reach.
+type fakePipeWriter struct {
+	writes   int
+	writeErr error
+	closeErr error
+}
+
+func (f *fakePipeWriter) Write(p []byte) (int, error) {
+	f.writes++
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+func (f *fakePipeWriter) Close() error                 { return nil }
+func (f *fakePipeWriter) CloseWithError(_ error) error { return f.closeErr }
+
+// TestWritePipeWriteErrorEarlyReturn covers the early return in writePipe when a
+// Write fails: the first write errors, so the remaining parts are never written.
+func TestWritePipeWriteErrorEarlyReturn(t *testing.T) {
+	w := &fakePipeWriter{writeErr: io.ErrClosedPipe}
+
+	writePipe(w, []byte("data"), []byte("more"))
+
+	if w.writes != 1 {
+		t.Fatalf("expected writePipe to stop after the first failing write, got %d writes", w.writes)
+	}
+}
+
+// fakeProvider is a minimal StreamingDeanonymizer that records whether Flush
+// was called.
+type fakeProvider struct{ flushed bool }
+
+func (p *fakeProvider) ProcessDataPayload(_ []byte) bool { return true }
+func (p *fakeProvider) Flush()                           { p.flushed = true }
+
+// TestHandleStreamEndCloseWithErrorLog covers the inner CloseWithError-error
+// log in handleStreamEnd (non-EOF read error whose CloseWithError also fails),
+// along with the partial-line flush and the provider Flush call.
+func TestHandleStreamEndCloseWithErrorLog(t *testing.T) {
+	prov := &fakeProvider{}
+	ctx := &streamContext{
+		pw:       &fakePipeWriter{closeErr: errors.New("close failed")},
+		replacer: strings.NewReplacer(),
+		provider: prov,
+	}
+
+	handleStreamEnd([]byte("partial line"), errors.New("read boom"), ctx)
+
+	if !prov.flushed {
+		t.Error("expected provider.Flush to be called on stream end")
+	}
+}
+
+// TestHandleStreamEndEOFSkipsClose covers the false branch of the
+// `readErr != io.EOF` condition: at EOF with an empty line buffer the close
+// block is skipped, but the provider is still flushed.
+func TestHandleStreamEndEOFSkipsClose(t *testing.T) {
+	prov := &fakeProvider{}
+	ctx := &streamContext{
+		pw:       &fakePipeWriter{closeErr: errors.New("should not be called")},
+		replacer: strings.NewReplacer(),
+		provider: prov,
+	}
+
+	handleStreamEnd(nil, io.EOF, ctx)
+
+	if !prov.flushed {
+		t.Error("expected provider.Flush to be called at EOF")
+	}
+}

--- a/internal/anonymizer/streaming_error_test.go
+++ b/internal/anonymizer/streaming_error_test.go
@@ -12,9 +12,12 @@ import (
 // early-return path and the inner failure-logging path in handleStreamEnd that
 // a real *io.PipeWriter (CloseWithError always returns nil) cannot reach.
 type fakePipeWriter struct {
-	writes   int
-	writeErr error
-	closeErr error
+	writes        int
+	written       []byte
+	writeErr      error
+	closeErr      error
+	closeErrCalls int
+	closeErrArg   error
 }
 
 func (f *fakePipeWriter) Write(p []byte) (int, error) {
@@ -22,10 +25,15 @@ func (f *fakePipeWriter) Write(p []byte) (int, error) {
 	if f.writeErr != nil {
 		return 0, f.writeErr
 	}
+	f.written = append(f.written, p...)
 	return len(p), nil
 }
-func (f *fakePipeWriter) Close() error                 { return nil }
-func (f *fakePipeWriter) CloseWithError(_ error) error { return f.closeErr }
+func (f *fakePipeWriter) Close() error { return nil }
+func (f *fakePipeWriter) CloseWithError(err error) error {
+	f.closeErrCalls++
+	f.closeErrArg = err
+	return f.closeErr
+}
 
 // TestWritePipeWriteErrorEarlyReturn covers the early return in writePipe when a
 // Write fails: the first write errors, so the remaining parts are never written.
@@ -51,16 +59,31 @@ func (p *fakeProvider) Flush()                           { p.flushed = true }
 // along with the partial-line flush and the provider Flush call.
 func TestHandleStreamEndCloseWithErrorLog(t *testing.T) {
 	prov := &fakeProvider{}
+	fw := &fakePipeWriter{closeErr: errors.New("close failed")}
+	// Replacer rewrites the token so we can confirm the partial line is flushed
+	// through the replacer rather than written raw or dropped.
 	ctx := &streamContext{
-		pw:       &fakePipeWriter{closeErr: errors.New("close failed")},
-		replacer: strings.NewReplacer(),
+		pw:       fw,
+		replacer: strings.NewReplacer("[PII_X]", "alice"),
 		provider: prov,
 	}
 
-	handleStreamEnd([]byte("partial line"), errors.New("read boom"), ctx)
+	readErr := errors.New("read boom")
+	handleStreamEnd([]byte("hi [PII_X]"), readErr, ctx)
 
 	if !prov.flushed {
 		t.Error("expected provider.Flush to be called on stream end")
+	}
+	// Partial-line flush: the leftover buffer must be written, token-replaced.
+	if string(fw.written) != "hi alice" {
+		t.Errorf("expected partial line flushed via replacer, got %q", string(fw.written))
+	}
+	// Non-EOF error must close the pipe with exactly that read error.
+	if fw.closeErrCalls != 1 {
+		t.Errorf("expected CloseWithError called once, got %d", fw.closeErrCalls)
+	}
+	if fw.closeErrArg != readErr {
+		t.Errorf("expected CloseWithError called with the read error, got %v", fw.closeErrArg)
 	}
 }
 
@@ -69,8 +92,9 @@ func TestHandleStreamEndCloseWithErrorLog(t *testing.T) {
 // block is skipped, but the provider is still flushed.
 func TestHandleStreamEndEOFSkipsClose(t *testing.T) {
 	prov := &fakeProvider{}
+	fw := &fakePipeWriter{closeErr: errors.New("should not be called")}
 	ctx := &streamContext{
-		pw:       &fakePipeWriter{closeErr: errors.New("should not be called")},
+		pw:       fw,
 		replacer: strings.NewReplacer(),
 		provider: prov,
 	}
@@ -79,5 +103,11 @@ func TestHandleStreamEndEOFSkipsClose(t *testing.T) {
 
 	if !prov.flushed {
 		t.Error("expected provider.Flush to be called at EOF")
+	}
+	// The EOF branch must NOT close the pipe with an error — that's the whole
+	// point of the `readErr != io.EOF` guard. Pin it: zero CloseWithError calls.
+	if fw.closeErrCalls != 0 {
+		t.Errorf("expected EOF path to skip CloseWithError, but it was called %d time(s) with %v",
+			fw.closeErrCalls, fw.closeErrArg)
 	}
 }

--- a/internal/anonymizer/streaming_error_test.go
+++ b/internal/anonymizer/streaming_error_test.go
@@ -1,11 +1,24 @@
 package anonymizer
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"log"
+	"os"
 	"strings"
 	"testing"
 )
+
+// captureLog redirects the standard logger to a buffer so a branch's
+// distinctive log message can be asserted. These tests are not parallel.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return &buf
+}
 
 // fakePipeWriter is a pipeWriter whose Write/CloseWithError behavior is
 // configurable and which counts Write calls. It exercises the writePipe
@@ -69,6 +82,7 @@ func TestHandleStreamEndCloseWithErrorLog(t *testing.T) {
 	}
 
 	readErr := errors.New("read boom")
+	logs := captureLog(t)
 	handleStreamEnd([]byte("hi [PII_X]"), readErr, ctx)
 
 	if !prov.flushed {
@@ -84,6 +98,13 @@ func TestHandleStreamEndCloseWithErrorLog(t *testing.T) {
 	}
 	if fw.closeErrArg != readErr {
 		t.Errorf("expected CloseWithError called with the read error, got %v", fw.closeErrArg)
+	}
+	// Pin the INNER branch: when CloseWithError itself returns an error (closeErr
+	// is set), handleStreamEnd must log it. Without this assertion the inner
+	// `if err != nil { log }` could be dropped and the test would still pass on
+	// the outer-branch checks alone.
+	if !strings.Contains(logs.String(), "CloseWithError failed") {
+		t.Errorf("expected inner CloseWithError-failure log, got: %q", logs.String())
 	}
 }
 

--- a/internal/anonymizer/streaming_gemini_test.go
+++ b/internal/anonymizer/streaming_gemini_test.go
@@ -205,7 +205,7 @@ func TestGeminiStreamingVerboseLogging(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, geminiDomain)
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {

--- a/internal/anonymizer/streaming_openai_test.go
+++ b/internal/anonymizer/streaming_openai_test.go
@@ -268,7 +268,7 @@ func TestOpenAIStreamingVerboseLogging(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, openAIDomain)
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -482,7 +482,7 @@ func TestDeepSeekReasoningVerboseLogging(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, deepSeekDomain)
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {

--- a/internal/anonymizer/streaming_provider_test.go
+++ b/internal/anonymizer/streaming_provider_test.go
@@ -19,7 +19,7 @@ func readStreamResultForDomain(t *testing.T, sseInput string, tokenMap map[strin
 	a.sessionMu.Unlock()
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, domain)
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 	got, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("reading streaming output: %v", err)
@@ -39,7 +39,7 @@ func readStreamResultVerbose(t *testing.T, sseInput string, tokenMap map[string]
 	a.sessionMu.Unlock()
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, domain)
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 	got, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("reading streaming output: %v", err)
@@ -130,8 +130,8 @@ func TestProviderForDomain(t *testing.T) {
 // implementation for every named Provider value.
 func TestNewStreamingDeanonymizer(t *testing.T) {
 	pr, pw := io.Pipe()
-	defer pr.Close() //nolint:errcheck
-	defer pw.Close() //nolint:errcheck
+	defer func() { _ = pr.Close() }()
+	defer func() { _ = pw.Close() }()
 
 	opts := streamDeanonymizerOpts{
 		pw:         pw,

--- a/internal/anonymizer/streaming_test.go
+++ b/internal/anonymizer/streaming_test.go
@@ -84,7 +84,7 @@ func readStreamResult(t *testing.T, sseInput string, tokenMap map[string]string)
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -508,7 +508,7 @@ func TestStreamingDeanonymizeVerboseLogging(t *testing.T) {
 	sseInput := makeSSETextDelta(prefix+token+" end") + "\n"
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -764,7 +764,7 @@ func TestProcessTextDeltaVerboseReplacementInFlush(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -801,7 +801,7 @@ func TestProcessJSONDeltaVerboseReplacementInFlush(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {
@@ -832,7 +832,7 @@ func TestProcessJSONDeltaVerboseReplacement(t *testing.T) {
 
 	src := io.NopCloser(strings.NewReader(sseInput))
 	rc := a.StreamingDeanonymize(src, sessionID, "api.anthropic.com")
-	defer rc.Close() //nolint:errcheck
+	defer func() { _ = rc.Close() }()
 
 	got, err := io.ReadAll(rc)
 	if err != nil {

--- a/internal/management/management.go
+++ b/internal/management/management.go
@@ -228,18 +228,18 @@ func (r *DomainRegistry) persist(domains []string) {
 	tmpName := tmp.Name()
 
 	if _, err := tmp.Write(append(data, '\n')); err != nil {
-		tmp.Close()        //nolint:errcheck // best-effort cleanup
-		os.Remove(tmpName) //nolint:errcheck,gosec // G703 -- tmpName from os.CreateTemp, not user input
+		_ = tmp.Close()        // best-effort cleanup
+		_ = os.Remove(tmpName) // best-effort cleanup
 		log.Printf("[DOMAINS] Persist error (write): %v", err)
 		return
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName) //nolint:errcheck,gosec // G703 -- tmpName from os.CreateTemp, not user input
+		_ = os.Remove(tmpName) // best-effort cleanup
 		log.Printf("[DOMAINS] Persist error (close): %v", err)
 		return
 	}
 	if err := os.Rename(tmpName, r.persistPath); err != nil { // #nosec G703 -- paths from trusted config
-		os.Remove(tmpName) //nolint:errcheck,gosec // G703 -- tmpName from os.CreateTemp, not user input
+		_ = os.Remove(tmpName) // best-effort cleanup
 		log.Printf("[DOMAINS] Persist error (rename): %v", err)
 		return
 	}

--- a/internal/management/management.go
+++ b/internal/management/management.go
@@ -205,6 +205,25 @@ func (r *DomainRegistry) snapshotLocked() []string {
 	return out
 }
 
+// jsonMarshalIndent is indirected through a package var so tests can force
+// the marshal-error path in persist; production always uses json.MarshalIndent.
+var jsonMarshalIndent = json.MarshalIndent
+
+// persistTempFile is the subset of *os.File that persist needs; abstracting
+// it lets tests inject write/close failures to exercise the cleanup paths.
+type persistTempFile interface {
+	Write(p []byte) (int, error)
+	Close() error
+	Name() string
+}
+
+// createPersistTempFile creates the temp file persist writes to before the
+// atomic rename. It is a package var so tests can inject a fake that fails on
+// Write/Close; *os.File from os.CreateTemp satisfies persistTempFile.
+var createPersistTempFile = func(dir, pattern string) (persistTempFile, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
 // persist writes the given domain snapshot to disk atomically.
 // It does NOT hold r.mu, so it won't block Has/All calls.
 func (r *DomainRegistry) persist(domains []string) {
@@ -212,7 +231,7 @@ func (r *DomainRegistry) persist(domains []string) {
 		return
 	}
 
-	data, err := json.MarshalIndent(domains, "", "  ")
+	data, err := jsonMarshalIndent(domains, "", "  ")
 	if err != nil {
 		log.Printf("[DOMAINS] Marshal error: %v", err)
 		return
@@ -220,7 +239,7 @@ func (r *DomainRegistry) persist(domains []string) {
 
 	// Atomic write: temp file → rename
 	dir := filepath.Dir(r.persistPath)
-	tmp, err := os.CreateTemp(dir, ".ai-domains-*.tmp")
+	tmp, err := createPersistTempFile(dir, ".ai-domains-*.tmp")
 	if err != nil {
 		log.Printf("[DOMAINS] Persist error (create temp): %v", err)
 		return
@@ -330,9 +349,6 @@ func validDomain(d string) bool {
 				return false
 			}
 			prefix, suffix := seg[:idx], seg[idx+1:]
-			if prefix == "" && suffix == "" {
-				continue // bare "*" already handled above; defensive
-			}
 			if prefix != "" && !labelPieceRegexp.MatchString(prefix) {
 				return false
 			}

--- a/internal/management/persist_error_test.go
+++ b/internal/management/persist_error_test.go
@@ -1,18 +1,32 @@
 package management
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"ai-anonymizing-proxy/internal/config"
 )
+
+// captureLog redirects the standard logger to a buffer for the duration of the
+// test so a branch's distinctive log message can be asserted. These tests are
+// not parallel, so the global SetOutput is safe.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return &buf
+}
 
 // fakeTempFile is an injectable persistTempFile that lets tests force the
 // write/close failure branches of persist without relying on real OS errors
@@ -85,8 +99,16 @@ func TestPersist_WriteError(t *testing.T) {
 	}
 
 	r := newRegistryWithPath(path)
+	logs := captureLog(t)
 	r.persist([]string{"api.example.com"})
 
+	// Pin the write-error branch by its distinctive log line. Without this, the
+	// "file not created" check alone is satisfied by the downstream Rename of the
+	// fake's (nonexistent) temp name, so the test would pass even if the
+	// write-error branch were removed.
+	if !strings.Contains(logs.String(), "Persist error (write)") {
+		t.Errorf("expected write-error branch to log %q, got: %q", "Persist error (write)", logs.String())
+	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("target file should not exist after write error, stat err = %v", err)
 	}
@@ -105,8 +127,14 @@ func TestPersist_CloseError(t *testing.T) {
 	}
 
 	r := newRegistryWithPath(path)
+	logs := captureLog(t)
 	r.persist([]string{"api.example.com"})
 
+	// Pin the close-error branch by its distinctive log line (see write-error
+	// test for why the file-absence check alone is insufficient).
+	if !strings.Contains(logs.String(), "Persist error (close)") {
+		t.Errorf("expected close-error branch to log %q, got: %q", "Persist error (close)", logs.String())
+	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("target file should not exist after close error, stat err = %v", err)
 	}

--- a/internal/management/persist_error_test.go
+++ b/internal/management/persist_error_test.go
@@ -211,9 +211,16 @@ func TestValidDomain_LabelSubstringWildcard(t *testing.T) {
 // H) writeJSON encode-error path: a channel cannot be JSON-encoded.
 func TestWriteJSON_EncodeError(t *testing.T) {
 	w := httptest.NewRecorder()
+	logs := captureLog(t)
 	// json.Encoder.Encode returns an error for unsupported types like chan.
 	writeJSON(w, http.StatusOK, make(chan int))
 
+	// Pin the encode-error branch by its distinctive log line. The status and
+	// Content-Type are written BEFORE Encode runs, so asserting only those would
+	// pass even if the error handling were removed.
+	if !strings.Contains(logs.String(), "JSON encode error") {
+		t.Errorf("expected encode-error branch to log %q, got: %q", "JSON encode error", logs.String())
+	}
 	if w.Code != http.StatusOK {
 		t.Errorf("expected status %d to be written before encode, got %d", http.StatusOK, w.Code)
 	}

--- a/internal/management/persist_error_test.go
+++ b/internal/management/persist_error_test.go
@@ -1,0 +1,218 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ai-anonymizing-proxy/internal/config"
+)
+
+// fakeTempFile is an injectable persistTempFile that lets tests force the
+// write/close failure branches of persist without relying on real OS errors
+// (which can't be provoked against a concrete *os.File, especially as root).
+type fakeTempFile struct {
+	name     string
+	writeErr error
+	closeErr error
+}
+
+func (f *fakeTempFile) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+
+func (f *fakeTempFile) Close() error { return f.closeErr }
+func (f *fakeTempFile) Name() string { return f.name }
+
+// newRegistryWithPath builds a DomainRegistry wired to persistPath without
+// loading from disk, so persist behavior can be tested in isolation.
+func newRegistryWithPath(persistPath string) *DomainRegistry {
+	return &DomainRegistry{
+		domains:     make(map[string]bool),
+		persistPath: persistPath,
+	}
+}
+
+// A) MarshalIndent error path (seam #1).
+func TestPersist_MarshalError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "domains.json")
+	orig := jsonMarshalIndent
+	defer func() { jsonMarshalIndent = orig }()
+	jsonMarshalIndent = func(_ any, _, _ string) ([]byte, error) {
+		return nil, errors.New("forced marshal error")
+	}
+
+	r := newRegistryWithPath(path)
+	r.persist([]string{"api.example.com"})
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should not be written on marshal error, stat err = %v", err)
+	}
+}
+
+// B) CreateTemp error path: parent directory of persistPath does not exist.
+func TestPersist_CreateTempError(t *testing.T) {
+	// "nope/sub" do not exist, so filepath.Dir(persistPath) is missing and
+	// os.CreateTemp fails.
+	path := filepath.Join(t.TempDir(), "nope", "sub", "domains.json")
+	r := newRegistryWithPath(path)
+	r.persist([]string{"api.example.com"})
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("target file should not exist after CreateTemp error, stat err = %v", err)
+	}
+}
+
+// C) temp-file Write error path (seam #2).
+func TestPersist_WriteError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "domains.json")
+	tmpName := filepath.Join(dir, "throwaway.tmp")
+
+	orig := createPersistTempFile
+	defer func() { createPersistTempFile = orig }()
+	createPersistTempFile = func(_, _ string) (persistTempFile, error) {
+		return &fakeTempFile{name: tmpName, writeErr: errors.New("forced write error")}, nil
+	}
+
+	r := newRegistryWithPath(path)
+	r.persist([]string{"api.example.com"})
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("target file should not exist after write error, stat err = %v", err)
+	}
+}
+
+// D) temp-file Close error path (seam #2): Write succeeds, Close fails.
+func TestPersist_CloseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "domains.json")
+	tmpName := filepath.Join(dir, "throwaway.tmp")
+
+	orig := createPersistTempFile
+	defer func() { createPersistTempFile = orig }()
+	createPersistTempFile = func(_, _ string) (persistTempFile, error) {
+		return &fakeTempFile{name: tmpName, closeErr: errors.New("forced close error")}, nil
+	}
+
+	r := newRegistryWithPath(path)
+	r.persist([]string{"api.example.com"})
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("target file should not exist after close error, stat err = %v", err)
+	}
+}
+
+// E) Rename error path: persistPath is an existing directory, so the rename of
+// the temp file onto it fails. Uses the real createPersistTempFile.
+func TestPersist_RenameError(t *testing.T) {
+	// persistPath itself is a directory; its parent (the enclosing temp dir)
+	// exists, so CreateTemp/Write/Close succeed but Rename onto a directory
+	// fails.
+	dirAsPath := t.TempDir()
+	r := newRegistryWithPath(dirAsPath)
+
+	// Must not panic; persist swallows the rename error after cleanup.
+	r.persist([]string{"api.example.com"})
+
+	// The destination is still a directory (rename did not replace it).
+	info, err := os.Stat(dirAsPath)
+	if err != nil {
+		t.Fatalf("stat persistPath: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("persistPath should still be a directory after rename failure")
+	}
+}
+
+// F) Happy path: persist writes valid JSON to the target file.
+func TestPersist_HappyPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "domains.json")
+	r := newRegistryWithPath(path)
+
+	want := []string{"api.anthropic.com", "api.example.com"}
+	r.persist(want)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("persist file not created: %v", err)
+	}
+	var got []string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON in persist file: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// G) validDomain label-substring wildcard prefix/suffix validity branches.
+func TestValidDomain_LabelSubstringWildcard(t *testing.T) {
+	cases := []struct {
+		domain string
+		valid  bool
+	}{
+		// Valid label-substring wildcard (suffix is valid label piece).
+		{"*-aiplatform.googleapis.com", true},
+		// Suffix invalid: "_" is not a valid label-piece character.
+		{"x*_.example.com", false},
+		// Prefix invalid: "_" is not a valid label-piece character.
+		{"_*x.example.com", false},
+	}
+	for _, tc := range cases {
+		if got := validDomain(tc.domain); got != tc.valid {
+			t.Errorf("validDomain(%q) = %v, want %v", tc.domain, got, tc.valid)
+		}
+	}
+}
+
+// H) writeJSON encode-error path: a channel cannot be JSON-encoded.
+func TestWriteJSON_EncodeError(t *testing.T) {
+	w := httptest.NewRecorder()
+	// json.Encoder.Encode returns an error for unsupported types like chan.
+	writeJSON(w, http.StatusOK, make(chan int))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d to be written before encode, got %d", http.StatusOK, w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json content type, got %q", ct)
+	}
+}
+
+// I) ListenAndServe error path: bind to an already-occupied port.
+func TestListenAndServe_BindError(t *testing.T) {
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to occupy a port: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected *net.TCPAddr, got %T", ln.Addr())
+	}
+	port := tcpAddr.Port
+
+	cfg := &config.Config{ManagementPort: port}
+	reg := NewDomainRegistry(cfg, "")
+	s := New(cfg, reg, nil)
+
+	if err := s.ListenAndServe(); err == nil {
+		t.Error("expected ListenAndServe to fail binding an occupied port, got nil")
+	}
+}

--- a/internal/management/persist_error_test.go
+++ b/internal/management/persist_error_test.go
@@ -149,10 +149,17 @@ func TestPersist_RenameError(t *testing.T) {
 	dirAsPath := t.TempDir()
 	r := newRegistryWithPath(dirAsPath)
 
+	logs := captureLog(t)
 	// Must not panic; persist swallows the rename error after cleanup.
 	r.persist([]string{"api.example.com"})
 
-	// The destination is still a directory (rename did not replace it).
+	// Pin the rename-error branch by its distinctive log line. The destination
+	// staying a directory is not branch-specific (it stays a directory whether or
+	// not the error is handled), so assert the log the cleanup branch emits.
+	if !strings.Contains(logs.String(), "Persist error (rename)") {
+		t.Errorf("expected rename-error branch to log %q, got: %q", "Persist error (rename)", logs.String())
+	}
+	// And the destination is still a directory (rename did not replace it).
 	info, err := os.Stat(dirAsPath)
 	if err != nil {
 		t.Fatalf("stat persistPath: %v", err)

--- a/internal/mitm/cert.go
+++ b/internal/mitm/cert.go
@@ -19,6 +19,14 @@ import (
 	"time"
 )
 
+// Indirection seams for deterministic testing of the crypto error paths,
+// which cannot be triggered with the real crypto/rand entropy source.
+var (
+	rsaGenerateKey        = rsa.GenerateKey
+	randInt               = rand.Int
+	x509CreateCertificate = x509.CreateCertificate
+)
+
 const maxCertCache = 10_000
 
 // CA holds certificate authority material for generating leaf certificates.
@@ -109,12 +117,12 @@ func LoadCA(certFile, keyFile string) (*CA, error) {
 // GenerateCA creates a new self-signed CA certificate and private key,
 // writing them to the specified PEM files.
 func GenerateCA(certFile, keyFile string) error {
-	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	key, err := rsaGenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return fmt.Errorf("generate key: %w", err)
 	}
 
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serial, err := randInt(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		return fmt.Errorf("generate serial: %w", err)
 	}
@@ -133,7 +141,7 @@ func GenerateCA(certFile, keyFile string) error {
 		MaxPathLen:            1,
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	derBytes, err := x509CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
 	if err != nil {
 		return fmt.Errorf("create CA cert: %w", err)
 	}
@@ -177,13 +185,13 @@ func (ca *CA) CertFor(host string) (*tls.Certificate, error) {
 
 	log.Printf("[MITM] Generating certificate for %s", host)
 
-	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	leafKey, err := rsaGenerateKey(rand.Reader, 2048)
 	if err != nil {
 		log.Printf("[MITM] Failed to generate key for %s: %v", host, err)
 		return nil, fmt.Errorf("generate leaf key: %w", err)
 	}
 
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serial, err := randInt(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		log.Printf("[MITM] Failed to generate serial for %s: %v", host, err)
 		return nil, fmt.Errorf("generate serial: %w", err)
@@ -199,7 +207,7 @@ func (ca *CA) CertFor(host string) (*tls.Certificate, error) {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &leafKey.PublicKey, ca.key)
+	derBytes, err := x509CreateCertificate(rand.Reader, template, ca.cert, &leafKey.PublicKey, ca.key)
 	if err != nil {
 		log.Printf("[MITM] Failed to sign certificate for %s: %v", host, err)
 		return nil, fmt.Errorf("sign leaf cert: %w", err)

--- a/internal/mitm/cert.go
+++ b/internal/mitm/cert.go
@@ -143,7 +143,7 @@ func GenerateCA(certFile, keyFile string) error {
 	if err != nil {
 		return fmt.Errorf("create cert file: %w", err)
 	}
-	defer certOut.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = certOut.Close() }() // best-effort close
 	if encErr := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); encErr != nil {
 		return fmt.Errorf("write cert PEM: %w", encErr)
 	}
@@ -153,7 +153,7 @@ func GenerateCA(certFile, keyFile string) error {
 	if err != nil {
 		return fmt.Errorf("create key file: %w", err)
 	}
-	defer keyOut.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = keyOut.Close() }() // best-effort close
 	if encErr := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); encErr != nil {
 		return fmt.Errorf("write key PEM: %w", encErr)
 	}

--- a/internal/mitm/cert.go
+++ b/internal/mitm/cert.go
@@ -19,12 +19,15 @@ import (
 	"time"
 )
 
-// Indirection seams for deterministic testing of the crypto error paths,
-// which cannot be triggered with the real crypto/rand entropy source.
+// Indirection seams for deterministic, portable testing of the crypto and
+// PEM-write error paths, which cannot otherwise be triggered (the real
+// crypto/rand entropy source never fails, and forcing a file-write error
+// would require platform-specific devices).
 var (
 	rsaGenerateKey        = rsa.GenerateKey
 	randInt               = rand.Int
 	x509CreateCertificate = x509.CreateCertificate
+	pemEncode             = pem.Encode
 )
 
 const maxCertCache = 10_000
@@ -152,7 +155,7 @@ func GenerateCA(certFile, keyFile string) error {
 		return fmt.Errorf("create cert file: %w", err)
 	}
 	defer func() { _ = certOut.Close() }() // best-effort close
-	if encErr := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); encErr != nil {
+	if encErr := pemEncode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); encErr != nil {
 		return fmt.Errorf("write cert PEM: %w", encErr)
 	}
 
@@ -162,7 +165,7 @@ func GenerateCA(certFile, keyFile string) error {
 		return fmt.Errorf("create key file: %w", err)
 	}
 	defer func() { _ = keyOut.Close() }() // best-effort close
-	if encErr := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); encErr != nil {
+	if encErr := pemEncode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); encErr != nil {
 		return fmt.Errorf("write key PEM: %w", encErr)
 	}
 

--- a/internal/mitm/cert_error_test.go
+++ b/internal/mitm/cert_error_test.go
@@ -1,0 +1,246 @@
+package mitm
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- LoadOrGenerateCA error paths ---
+
+func TestLoadOrGenerateCA_GenerateFails(t *testing.T) {
+	dir := t.TempDir()
+	// Non-existent subdirectory makes GenerateCA's os.OpenFile fail.
+	certFile := filepath.Join(dir, "missing", "ca.pem")
+	keyFile := filepath.Join(dir, "missing", "ca.key")
+
+	_, err := LoadOrGenerateCA(certFile, keyFile)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to generate CA") {
+		t.Errorf("error = %q, want contains %q", err.Error(), "failed to generate CA")
+	}
+}
+
+func TestLoadOrGenerateCA_LoadGeneratedFails(t *testing.T) {
+	dir := t.TempDir()
+	// Same path for cert and key: GenerateCA writes the cert then truncates and
+	// overwrites the same file with the key, so the reload finds a key where a
+	// certificate is expected.
+	path := filepath.Join(dir, "ca.pem")
+
+	_, err := LoadOrGenerateCA(path, path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to load generated CA") {
+		t.Errorf("error = %q, want contains %q", err.Error(), "failed to load generated CA")
+	}
+}
+
+// --- LoadCA: key parses as non-RSA via PKCS8 fallback ---
+
+func TestLoadCA_KeyNotRSA(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "ca.pem")
+	keyFile := filepath.Join(dir, "ca.key")
+	if err := GenerateCA(certFile, keyFile); err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	// Overwrite the key file with a PKCS8-encoded ECDSA (non-RSA) key.
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if writeErr := os.WriteFile(keyFile, pemBytes, 0600); writeErr != nil {
+		t.Fatalf("WriteFile: %v", writeErr)
+	}
+
+	_, err = LoadCA(certFile, keyFile)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not RSA") {
+		t.Errorf("error = %q, want contains %q", err.Error(), "not RSA")
+	}
+}
+
+// --- GenerateCA crypto error seams ---
+
+func TestGenerateCA_SeamErrors(t *testing.T) {
+	origRSA := rsaGenerateKey
+	origInt := randInt
+	origCreate := x509CreateCertificate
+	defer func() {
+		rsaGenerateKey = origRSA
+		randInt = origInt
+		x509CreateCertificate = origCreate
+	}()
+
+	tests := []struct {
+		name    string
+		setup   func()
+		certOut string // "" => temp file
+		keyOut  string // "" => temp file
+		wantErr string
+	}{
+		{
+			name: "rsaGenerateKey error",
+			setup: func() {
+				rsaGenerateKey = func(io.Reader, int) (*rsa.PrivateKey, error) {
+					return nil, errors.New("no key")
+				}
+			},
+			wantErr: "generate key",
+		},
+		{
+			name: "randInt error",
+			setup: func() {
+				randInt = func(io.Reader, *big.Int) (*big.Int, error) {
+					return nil, errors.New("no serial")
+				}
+			},
+			wantErr: "generate serial",
+		},
+		{
+			name: "x509CreateCertificate error",
+			setup: func() {
+				x509CreateCertificate = func(io.Reader, *x509.Certificate, *x509.Certificate, any, any) ([]byte, error) {
+					return nil, errors.New("no cert")
+				}
+			},
+			wantErr: "create CA cert",
+		},
+		{
+			name:    "cert write error",
+			setup:   func() {},
+			certOut: "/dev/full",
+			wantErr: "write cert PEM",
+		},
+		{
+			name:    "key write error",
+			setup:   func() {},
+			keyOut:  "/dev/full",
+			wantErr: "write key PEM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset seams to defaults before each subtest.
+			rsaGenerateKey = origRSA
+			randInt = origInt
+			x509CreateCertificate = origCreate
+			tt.setup()
+
+			dir := t.TempDir()
+			certFile := tt.certOut
+			if certFile == "" {
+				certFile = filepath.Join(dir, "ca.pem")
+			}
+			keyFile := tt.keyOut
+			if keyFile == "" {
+				keyFile = filepath.Join(dir, "ca.key")
+			}
+
+			err := GenerateCA(certFile, keyFile)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want contains %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// --- CertFor crypto error seams ---
+
+func TestCertFor_SeamErrors(t *testing.T) {
+	certFile, keyFile := tempCA(t)
+	ca, err := LoadCA(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+
+	origRSA := rsaGenerateKey
+	origInt := randInt
+	origCreate := x509CreateCertificate
+	defer func() {
+		rsaGenerateKey = origRSA
+		randInt = origInt
+		x509CreateCertificate = origCreate
+	}()
+
+	tests := []struct {
+		name    string
+		host    string
+		setup   func()
+		wantErr string
+	}{
+		{
+			name: "leaf rsaGenerateKey error",
+			host: "host-a.example",
+			setup: func() {
+				rsaGenerateKey = func(io.Reader, int) (*rsa.PrivateKey, error) {
+					return nil, errors.New("no key")
+				}
+			},
+			wantErr: "generate leaf key",
+		},
+		{
+			name: "leaf randInt error",
+			host: "host-b.example",
+			setup: func() {
+				randInt = func(io.Reader, *big.Int) (*big.Int, error) {
+					return nil, errors.New("no serial")
+				}
+			},
+			wantErr: "generate serial",
+		},
+		{
+			name: "sign error",
+			host: "host-c.example",
+			setup: func() {
+				x509CreateCertificate = func(io.Reader, *x509.Certificate, *x509.Certificate, any, any) ([]byte, error) {
+					return nil, errors.New("no cert")
+				}
+			},
+			wantErr: "sign leaf cert",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rsaGenerateKey = origRSA
+			randInt = origInt
+			x509CreateCertificate = origCreate
+			tt.setup()
+
+			_, err := ca.CertFor(tt.host)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want contains %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mitm/cert_error_test.go
+++ b/internal/mitm/cert_error_test.go
@@ -88,17 +88,17 @@ func TestGenerateCA_SeamErrors(t *testing.T) {
 	origRSA := rsaGenerateKey
 	origInt := randInt
 	origCreate := x509CreateCertificate
+	origPem := pemEncode
 	defer func() {
 		rsaGenerateKey = origRSA
 		randInt = origInt
 		x509CreateCertificate = origCreate
+		pemEncode = origPem
 	}()
 
 	tests := []struct {
 		name    string
 		setup   func()
-		certOut string // "" => temp file
-		keyOut  string // "" => temp file
 		wantErr string
 	}{
 		{
@@ -129,15 +129,29 @@ func TestGenerateCA_SeamErrors(t *testing.T) {
 			wantErr: "create CA cert",
 		},
 		{
-			name:    "cert write error",
-			setup:   func() {},
-			certOut: "/dev/full",
+			// The first pemEncode call (the cert PEM) fails — portable across
+			// runners, unlike a platform-specific full device.
+			name: "cert write error",
+			setup: func() {
+				pemEncode = func(io.Writer, *pem.Block) error {
+					return errors.New("write failed")
+				}
+			},
 			wantErr: "write cert PEM",
 		},
 		{
-			name:    "key write error",
-			setup:   func() {},
-			keyOut:  "/dev/full",
+			// The cert PEM write succeeds; the second call (the key PEM) fails.
+			name: "key write error",
+			setup: func() {
+				calls := 0
+				pemEncode = func(w io.Writer, b *pem.Block) error {
+					calls++
+					if calls == 1 {
+						return origPem(w, b)
+					}
+					return errors.New("write failed")
+				}
+			},
 			wantErr: "write key PEM",
 		},
 	}
@@ -148,17 +162,12 @@ func TestGenerateCA_SeamErrors(t *testing.T) {
 			rsaGenerateKey = origRSA
 			randInt = origInt
 			x509CreateCertificate = origCreate
+			pemEncode = origPem
 			tt.setup()
 
 			dir := t.TempDir()
-			certFile := tt.certOut
-			if certFile == "" {
-				certFile = filepath.Join(dir, "ca.pem")
-			}
-			keyFile := tt.keyOut
-			if keyFile == "" {
-				keyFile = filepath.Join(dir, "ca.key")
-			}
+			certFile := filepath.Join(dir, "ca.pem")
+			keyFile := filepath.Join(dir, "ca.key")
 
 			err := GenerateCA(certFile, keyFile)
 			if err == nil {

--- a/internal/mitm/mitm.go
+++ b/internal/mitm/mitm.go
@@ -22,7 +22,7 @@ func HandleConn(clientConn net.Conn, host string, ca *CA, handler http.Handler) 
 		log.Printf("[MITM] TLS handshake failed for %s: %v", host, err)
 		return
 	}
-	defer tlsConn.Close() //nolint:errcheck // best-effort close on TLS connection
+	defer func() { _ = tlsConn.Close() }() // best-effort close on TLS connection
 
 	// Determine which protocol was negotiated
 	proto := tlsConn.ConnectionState().NegotiatedProtocol
@@ -51,7 +51,7 @@ func HandleConn(clientConn net.Conn, host string, ca *CA, handler http.Handler) 
 			ReadHeaderTimeout: 10 * time.Second,
 		}
 		ln := &singleConnListener{conn: tlsConn}
-		srv.Serve(ln) //nolint:errcheck // always ErrServerClosed for single-conn listener
+		_ = srv.Serve(ln) // always ErrServerClosed for single-conn listener
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -269,7 +269,7 @@ func (s *Server) handleMITMTunnel(w http.ResponseWriter, r *http.Request, host, 
 		log.Printf("[MITM] %s Hijack error for %s: %v", remoteHash, host, err)
 		return
 	}
-	defer clientConn.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = clientConn.Close() }()
 
 	// Build a handler that anonymizes and forwards requests
 	ctx := mitmContext{host: host, domain: domain, remoteHash: remoteHash}
@@ -351,7 +351,7 @@ func (s *Server) forwardMITMRequest(rw http.ResponseWriter, req *http.Request, s
 	if s.m != nil {
 		s.m.RecordUpstreamLatency(time.Since(upstreamStart))
 	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = resp.Body.Close() }()
 
 	// De-anonymize response before returning to client
 	s.deanonymizeResponseBody(resp, sessionID, domain)
@@ -359,7 +359,7 @@ func (s *Server) forwardMITMRequest(rw http.ResponseWriter, req *http.Request, s
 	removeHopByHop(resp.Header)
 	copyHeader(rw.Header(), resp.Header)
 	rw.WriteHeader(resp.StatusCode)
-	flushingCopy(rw, resp.Body) //nolint:errcheck // client disconnect; headers already sent
+	flushingCopy(rw, resp.Body)
 }
 
 // handleOpaqueTunnel establishes a TCP tunnel without inspecting the traffic.
@@ -381,7 +381,7 @@ func (s *Server) handleOpaqueTunnel(w http.ResponseWriter, r *http.Request, host
 		http.Error(w, errBadGateway, http.StatusBadGateway)
 		return
 	}
-	defer destConn.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = destConn.Close() }()
 
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
@@ -396,12 +396,12 @@ func (s *Server) handleOpaqueTunnel(w http.ResponseWriter, r *http.Request, host
 		log.Printf("[TUNNEL] %s Hijack error for %s: %v", hashRemoteAddr(r.RemoteAddr), host, err)
 		return
 	}
-	defer clientConn.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = clientConn.Close() }()
 
 	// Bidirectional copy
 	done := make(chan struct{}, 2)
-	go func() { io.Copy(destConn, clientConn); done <- struct{}{} }() //nolint:errcheck // tunnel; EOF is normal
-	go func() { io.Copy(clientConn, destConn); done <- struct{}{} }() //nolint:errcheck // tunnel; EOF is normal
+	go func() { _, _ = io.Copy(destConn, clientConn); done <- struct{}{} }() // tunnel; EOF is normal
+	go func() { _, _ = io.Copy(clientConn, destConn); done <- struct{}{} }() // tunnel; EOF is normal
 	<-done
 }
 
@@ -487,7 +487,7 @@ func (s *Server) forward(w http.ResponseWriter, r *http.Request, sessionID strin
 	if s.m != nil {
 		s.m.RecordUpstreamLatency(time.Since(upstreamStart))
 	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort close
+	defer func() { _ = resp.Body.Close() }()
 
 	// De-anonymize response before returning to client
 	s.deanonymizeResponseBody(resp, sessionID, domain)
@@ -495,7 +495,7 @@ func (s *Server) forward(w http.ResponseWriter, r *http.Request, sessionID strin
 	removeHopByHop(resp.Header)
 	copyHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
-	flushingCopy(w, resp.Body) //nolint:errcheck // client disconnect; headers already sent
+	flushingCopy(w, resp.Body)
 }
 
 const maxRequestBody = 50 << 20 // 50 MB
@@ -506,7 +506,7 @@ func (s *Server) anonymizeRequestBody(r *http.Request) (string, error) {
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBody+1))
-	r.Body.Close() //nolint:errcheck // body already read; close is best-effort
+	_ = r.Body.Close() // body already read; close is best-effort
 	if err != nil {
 		if s.m != nil {
 			s.m.ErrorsAnonymize.Add(1)
@@ -563,7 +563,7 @@ func (s *Server) deanonymizeResponseBody(resp *http.Response, sessionID string, 
 	}
 
 	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close() //nolint:errcheck // body already read; close is best-effort
+	_ = resp.Body.Close() // body already read; close is best-effort
 	if err != nil {
 		resp.Body = http.NoBody
 		return
@@ -708,7 +708,7 @@ func flushingCopy(dst io.Writer, src io.Reader) {
 	for {
 		n, err := src.Read(buf)
 		if n > 0 {
-			dst.Write(buf[:n]) //nolint:errcheck // caller ignores; headers already sent
+			_, _ = dst.Write(buf[:n]) // caller ignores; headers already sent
 			if canFlush {
 				flusher.Flush()
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -105,13 +105,20 @@ var errPrivateIP = fmt.Errorf("connection to private IP blocked")
 // can substitute a deterministic resolver.
 var lookupIPAddr = net.DefaultResolver.LookupIPAddr
 
+// dialContextFn performs the actual outbound dial. It is a package var (the real
+// (*net.Dialer).DialContext) so tests can observe the exact address
+// ssrfSafeDialContext dials — proving the direct-dial fallback uses the raw addr
+// and the post-resolution dial targets the inspected IP (not the original
+// hostname), which the SSRF protection depends on.
+var dialContextFn = (*net.Dialer).DialContext
+
 // ssrfSafeDialContext wraps a net.Dialer and checks the resolved IP address
 // at connection time — eliminating the TOCTOU gap between DNS resolution and dial.
 func ssrfSafeDialContext(d *net.Dialer) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
-			return d.DialContext(ctx, network, addr)
+			return dialContextFn(d, ctx, network, addr)
 		}
 
 		// Resolve the hostname ourselves so we can inspect the IPs
@@ -132,7 +139,7 @@ func ssrfSafeDialContext(d *net.Dialer) func(ctx context.Context, network, addr 
 		if len(ips) == 0 {
 			return nil, fmt.Errorf("proxy: no IP addresses returned for host %q", host)
 		}
-		return d.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+		return dialContextFn(d, ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -44,27 +44,28 @@ const (
 	errBadGateway         = "bad gateway"
 )
 
+var defaultPrivateCIDRs = []string{
+	"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8",
+	"169.254.0.0/16", "::1/128", "fc00::/7", "fe80::/10",
+}
+
 // privateNetworks lists CIDR ranges that must never be reachable via CONNECT
 // or plain-HTTP forwarding (SSRF protection).
-var privateNetworks []*net.IPNet
+var privateNetworks = mustParsePrivateNetworks(defaultPrivateCIDRs)
 
-func init() {
-	for _, cidr := range []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"::1/128",
-		"fc00::/7",
-		"fe80::/10",
-	} {
+// mustParsePrivateNetworks parses CIDR strings, panicking on an invalid entry
+// (a programmer error in the hardcoded defaults). Returning an error here and
+// panicking keeps the guard while making it unit-testable.
+func mustParsePrivateNetworks(cidrs []string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
 		_, network, err := net.ParseCIDR(cidr)
 		if err != nil {
-			log.Fatalf("proxy: invalid private network CIDR %q: %v", cidr, err)
+			panic(fmt.Sprintf("proxy: invalid private network CIDR %q: %v", cidr, err))
 		}
-		privateNetworks = append(privateNetworks, network)
+		nets = append(nets, network)
 	}
+	return nets
 }
 
 // hashRemoteAddr returns the first 8 hex characters of sha256(addr).
@@ -100,6 +101,10 @@ func isPrivateIP(ip net.IP) bool {
 
 var errPrivateIP = fmt.Errorf("connection to private IP blocked")
 
+// lookupIPAddr resolves a hostname to IP addresses. It is a package var so tests
+// can substitute a deterministic resolver.
+var lookupIPAddr = net.DefaultResolver.LookupIPAddr
+
 // ssrfSafeDialContext wraps a net.Dialer and checks the resolved IP address
 // at connection time — eliminating the TOCTOU gap between DNS resolution and dial.
 func ssrfSafeDialContext(d *net.Dialer) func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -110,7 +115,7 @@ func ssrfSafeDialContext(d *net.Dialer) func(ctx context.Context, network, addr 
 		}
 
 		// Resolve the hostname ourselves so we can inspect the IPs
-		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		ips, err := lookupIPAddr(ctx, host)
 		if err != nil {
 			return nil, err
 		}
@@ -500,6 +505,12 @@ func (s *Server) forward(w http.ResponseWriter, r *http.Request, sessionID strin
 
 const maxRequestBody = 50 << 20 // 50 MB
 
+// randRead fills b with cryptographically secure random bytes. It is a package
+// var so tests can inject a failing reader to exercise the timestamp fallback;
+// crypto/rand.Read itself treats a reader error as fatal and cannot be made to
+// return one in-process.
+var randRead = rand.Read
+
 func (s *Server) anonymizeRequestBody(r *http.Request) (string, error) {
 	if r.Body == nil || r.ContentLength == 0 {
 		return "", nil
@@ -519,7 +530,7 @@ func (s *Server) anonymizeRequestBody(r *http.Request) (string, error) {
 
 	var sessionID string
 	b := make([]byte, 8)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := randRead(b); err != nil {
 		sessionID = fmt.Sprintf("%d", time.Now().UnixNano())
 	} else {
 		sessionID = hex.EncodeToString(b)

--- a/internal/proxy/proxy_coverage_test.go
+++ b/internal/proxy/proxy_coverage_test.go
@@ -54,26 +54,33 @@ func TestMustParsePrivateNetworks_Valid(t *testing.T) {
 
 func TestSsrfSafeDialContext_Branches(t *testing.T) {
 	origLookup := lookupIPAddr
-	defer func() { lookupIPAddr = origLookup }()
+	origDial := dialContextFn
+	defer func() { lookupIPAddr = origLookup; dialContextFn = origDial }()
 
 	dialFn := ssrfSafeDialContext(&net.Dialer{})
 
 	t.Run("split host port error falls to direct dial", func(t *testing.T) {
-		// No colon -> net.SplitHostPort fails -> the direct d.DialContext path,
-		// which must NOT consult the resolver. Pin that branch: fail loudly if
-		// lookup is reached (it would be, if the SplitHostPort-error fallback
-		// were removed and control fell through to the lookup path).
+		// No colon -> net.SplitHostPort fails -> the direct-dial fallback, which
+		// must call the dialer with the RAW addr and must NOT consult the
+		// resolver. Observe the dial target to pin the fallback: if the impl
+		// returned the SplitHostPort error directly instead, the dialer would
+		// never be called and dialedAddr would stay empty.
 		lookupReached := false
 		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
 			lookupReached = true
 			return nil, errors.New("resolver must not be reached on the direct-dial path")
 		}
-		// Canceled context so the direct dial returns immediately.
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		_, err := dialFn(ctx, "tcp", "hostwithoutport")
+		dialedAddr := ""
+		dialContextFn = func(_ *net.Dialer, _ context.Context, _ string, addr string) (net.Conn, error) {
+			dialedAddr = addr
+			return nil, errors.New("dial blocked")
+		}
+		_, err := dialFn(context.Background(), "tcp", "hostwithoutport")
 		if err == nil {
 			t.Fatal("expected error from direct dial of invalid address")
+		}
+		if dialedAddr != "hostwithoutport" {
+			t.Errorf("expected direct dial of the raw addr %q, got dialed=%q", "hostwithoutport", dialedAddr)
 		}
 		if lookupReached {
 			t.Error("SplitHostPort-error path must dial directly without resolving")
@@ -110,16 +117,24 @@ func TestSsrfSafeDialContext_Branches(t *testing.T) {
 		}
 	})
 
-	t.Run("final dial executes", func(t *testing.T) {
+	t.Run("final dial targets the resolved IP", func(t *testing.T) {
 		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
 			return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
 		}
-		// Canceled context makes the real dial return immediately.
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		_, err := dialFn(ctx, "tcp", "example.com:443")
+		dialedAddr := ""
+		dialContextFn = func(_ *net.Dialer, _ context.Context, _ string, addr string) (net.Conn, error) {
+			dialedAddr = addr
+			return nil, errors.New("dial blocked")
+		}
+		_, err := dialFn(context.Background(), "tcp", "example.com:443")
 		if err == nil {
-			t.Fatal("expected error from canceled-context dial")
+			t.Fatal("expected error from the stubbed dial")
+		}
+		// SSRF-critical: the dial MUST target the inspected IP, not the original
+		// hostname. This proves it would NOT still pass if ssrfSafeDialContext
+		// stopped dialing or dialed "example.com:443" instead of the checked IP.
+		if dialedAddr != "8.8.8.8:443" {
+			t.Errorf("expected dial to the resolved IP %q, got %q", "8.8.8.8:443", dialedAddr)
 		}
 	})
 }
@@ -201,22 +216,21 @@ func TestDeanonymizeResponseBody_DecompressError(t *testing.T) {
 	resp.Header.Set("Content-Type", "application/json")
 	resp.Header.Set("Content-Encoding", "gzip")
 
-	// Bad gzip -> decompressResponse returns an error -> error-log branch, then
-	// deanonymizeResponseBody continues defensively. Prove two things:
-	//  1. the resulting body is still readable (ReadAll succeeds with no error),
-	//     not a panic or a propagated read failure; and
-	//  2. the failure branch was actually taken — a SUCCESSFUL decode deletes the
-	//     Content-Encoding header, so its retention pins the error path (and
-	//     rules out a silent no-op or the success path).
+	// Bad gzip -> decompressResponse returns an error -> deanonymizeResponseBody's
+	// error-LOG branch fires. The branch's only distinctive effect is the log:
+	// the body stays readable and Content-Encoding stays "gzip" whether the branch
+	// logs or is reduced to `_ = decompressResponse(resp)`. So assert the log line
+	// to prove the branch's effect ran; deleting it must fail the test.
+	logs := captureLog(t)
 	srv.deanonymizeResponseBody(resp, "sess-x", "api.example.com")
+	if !strings.Contains(logs.String(), "decompression error") {
+		t.Errorf("expected the decompression-error branch to log, got: %q", logs.String())
+	}
 	if resp.Body == nil {
 		t.Fatal("expected non-nil body after deanonymize")
 	}
 	if _, err := io.ReadAll(resp.Body); err != nil {
 		t.Fatalf("body not readable after failed decompression: %v", err)
-	}
-	if enc := resp.Header.Get("Content-Encoding"); enc != "gzip" {
-		t.Fatalf("expected Content-Encoding retained on decode failure (error branch), got %q", enc)
 	}
 }
 

--- a/internal/proxy/proxy_coverage_test.go
+++ b/internal/proxy/proxy_coverage_test.go
@@ -223,15 +223,27 @@ func TestDeanonymizeResponseBody_DecompressError(t *testing.T) {
 // --- E) Handler-path branches ---
 
 // fakeConnHijacker is an http.Hijacker whose Hijack() always returns an error.
+// fakeConnHijacker is an http.Hijacker whose Hijack always errors. It records
+// whether WriteHeader and Hijack were invoked so tests can prove the tunnel
+// reached the CONNECT-success write and the hijack attempt before the error
+// (a bare ResponseRecorder defaults Code to 200, so Code alone proves nothing).
 type fakeConnHijacker struct {
 	*httptest.ResponseRecorder
+	wroteHeader  bool
+	hijackCalled bool
 }
 
 func newFakeConnHijacker() *fakeConnHijacker {
 	return &fakeConnHijacker{ResponseRecorder: httptest.NewRecorder()}
 }
 
-func (fakeConnHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (h *fakeConnHijacker) WriteHeader(code int) {
+	h.wroteHeader = true
+	h.ResponseRecorder.WriteHeader(code)
+}
+
+func (h *fakeConnHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijackCalled = true
 	return nil, nil, errors.New("hijack failed")
 }
 
@@ -302,9 +314,14 @@ func TestHandleMITMTunnel_HijackError(t *testing.T) {
 	w := newFakeConnHijacker()
 	srv.handleMITMTunnel(w, req, "api.example.com:443", "api.example.com")
 
-	// WriteHeader(200) is called before Hijack(); after Hijack errors it returns.
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 written before hijack, got %d", w.Code)
+	// Prove the hijack-error branch was actually reached: the CONNECT-success
+	// WriteHeader(200) ran (assert wroteHeader, not Code — a recorder defaults to
+	// 200) and Hijack() was attempted before the error return.
+	if !w.wroteHeader || w.Code != http.StatusOK {
+		t.Fatalf("expected WriteHeader(200) before hijack (wrote=%v code=%d)", w.wroteHeader, w.Code)
+	}
+	if !w.hijackCalled {
+		t.Fatal("expected handleMITMTunnel to attempt Hijack before the error return")
 	}
 }
 
@@ -423,9 +440,14 @@ func TestHandleOpaqueTunnel_HijackError(t *testing.T) {
 	w := newFakeConnHijacker()
 	srv.handleOpaqueTunnel(w, req, "example.com:443")
 
-	// WriteHeader(200) is sent before Hijack(); Hijack errors then returns.
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 written before hijack, got %d", w.Code)
+	// Prove the hijack-error branch was reached: the CONNECT-success
+	// WriteHeader(200) ran (assert wroteHeader, not Code — a recorder defaults to
+	// 200) and Hijack() was attempted before the error return.
+	if !w.wroteHeader || w.Code != http.StatusOK {
+		t.Fatalf("expected WriteHeader(200) before hijack (wrote=%v code=%d)", w.wroteHeader, w.Code)
+	}
+	if !w.hijackCalled {
+		t.Fatal("expected handleOpaqueTunnel to attempt Hijack before the error return")
 	}
 }
 

--- a/internal/proxy/proxy_coverage_test.go
+++ b/internal/proxy/proxy_coverage_test.go
@@ -177,13 +177,23 @@ func TestDeanonymizeResponseBody_DecompressError(t *testing.T) {
 	resp.Header.Set("Content-Type", "application/json")
 	resp.Header.Set("Content-Encoding", "gzip")
 
-	// Bad gzip -> decompressResponse returns an error -> error-log branch.
-	// Must not panic; should still proceed and produce a readable body.
+	// Bad gzip -> decompressResponse returns an error -> error-log branch, then
+	// deanonymizeResponseBody continues defensively. Prove two things:
+	//  1. the resulting body is still readable (ReadAll succeeds with no error),
+	//     not a panic or a propagated read failure; and
+	//  2. the failure branch was actually taken — a SUCCESSFUL decode deletes the
+	//     Content-Encoding header, so its retention pins the error path (and
+	//     rules out a silent no-op or the success path).
 	srv.deanonymizeResponseBody(resp, "sess-x", "api.example.com")
 	if resp.Body == nil {
 		t.Fatal("expected non-nil body after deanonymize")
 	}
-	_, _ = io.ReadAll(resp.Body)
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("body not readable after failed decompression: %v", err)
+	}
+	if enc := resp.Header.Get("Content-Encoding"); enc != "gzip" {
+		t.Fatalf("expected Content-Encoding retained on decode failure (error branch), got %q", enc)
+	}
 }
 
 // --- E) Handler-path branches ---

--- a/internal/proxy/proxy_coverage_test.go
+++ b/internal/proxy/proxy_coverage_test.go
@@ -1,0 +1,410 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ai-anonymizing-proxy/internal/config"
+	"ai-anonymizing-proxy/internal/management"
+	"ai-anonymizing-proxy/internal/metrics"
+)
+
+// --- A) mustParsePrivateNetworks ---
+
+func TestMustParsePrivateNetworks_Panics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for invalid CIDR")
+		}
+	}()
+	mustParsePrivateNetworks([]string{"not-a-cidr"})
+}
+
+func TestMustParsePrivateNetworks_Valid(t *testing.T) {
+	nets := mustParsePrivateNetworks([]string{"10.0.0.0/8"})
+	if len(nets) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(nets))
+	}
+}
+
+// --- B) ssrfSafeDialContext seam-driven branches ---
+
+func TestSsrfSafeDialContext_Branches(t *testing.T) {
+	origLookup := lookupIPAddr
+	defer func() { lookupIPAddr = origLookup }()
+
+	dialFn := ssrfSafeDialContext(&net.Dialer{})
+
+	t.Run("split host port error falls to direct dial", func(t *testing.T) {
+		// No colon -> net.SplitHostPort fails -> d.DialContext path.
+		// Use a canceled context so the dial returns immediately.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := dialFn(ctx, "tcp", "hostwithoutport")
+		if err == nil {
+			t.Fatal("expected error from direct dial of invalid address")
+		}
+	})
+
+	t.Run("lookup error", func(t *testing.T) {
+		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
+			return nil, errors.New("dns boom")
+		}
+		_, err := dialFn(context.Background(), "tcp", "example.com:443")
+		if err == nil || !strings.Contains(err.Error(), "dns boom") {
+			t.Fatalf("expected lookup error, got %v", err)
+		}
+	})
+
+	t.Run("private IP blocked", func(t *testing.T) {
+		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}, nil
+		}
+		_, err := dialFn(context.Background(), "tcp", "example.com:443")
+		if !errors.Is(err, errPrivateIP) {
+			t.Fatalf("expected errPrivateIP, got %v", err)
+		}
+	})
+
+	t.Run("empty IPs", func(t *testing.T) {
+		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{}, nil
+		}
+		_, err := dialFn(context.Background(), "tcp", "example.com:443")
+		if err == nil || !strings.Contains(err.Error(), "no IP addresses") {
+			t.Fatalf("expected 'no IP addresses' error, got %v", err)
+		}
+	})
+
+	t.Run("final dial executes", func(t *testing.T) {
+		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}}, nil
+		}
+		// Canceled context makes the real dial return immediately.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := dialFn(ctx, "tcp", "example.com:443")
+		if err == nil {
+			t.Fatal("expected error from canceled-context dial")
+		}
+	})
+}
+
+// --- C) anonymizeRequestBody ---
+
+// infiniteReader yields filler bytes forever (until LimitReader caps it).
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+func (infiniteReader) Close() error { return nil }
+
+func TestAnonymizeRequestBody_BodyTooLarge(t *testing.T) {
+	srv := newTestProxyServer(t)
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://example.com", nil)
+	req.Body = infiniteReader{}
+	req.ContentLength = maxRequestBody + 10
+
+	sessionID, err := srv.anonymizeRequestBody(req)
+	if err == nil {
+		t.Fatal("expected error for body exceeding limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected 'exceeds' error, got %v", err)
+	}
+	if sessionID != "" {
+		t.Fatalf("expected empty sessionID, got %q", sessionID)
+	}
+}
+
+func TestAnonymizeRequestBody_RandFallback(t *testing.T) {
+	srv := newTestProxyServer(t)
+
+	orig := randRead
+	defer func() { randRead = orig }()
+	randRead = func([]byte) (int, error) { return 0, errors.New("no entropy") }
+
+	body := `{"message":"hi"}`
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://example.com",
+		strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	sessionID, err := srv.anonymizeRequestBody(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionID == "" {
+		t.Fatal("expected non-empty timestamp-fallback sessionID")
+	}
+	// Fallback is a UnixNano integer string: all digits.
+	for _, c := range sessionID {
+		if c < '0' || c > '9' {
+			t.Fatalf("expected all-digit fallback sessionID, got %q", sessionID)
+		}
+	}
+	srv.anon.DeleteSession(sessionID)
+}
+
+// --- D) deanonymizeResponseBody decompression error ---
+
+func TestDeanonymizeResponseBody_DecompressError(t *testing.T) {
+	srv := newTestProxyServer(t)
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("this is not gzip")),
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set("Content-Encoding", "gzip")
+
+	// Bad gzip -> decompressResponse returns an error -> error-log branch.
+	// Must not panic; should still proceed and produce a readable body.
+	srv.deanonymizeResponseBody(resp, "sess-x", "api.example.com")
+	if resp.Body == nil {
+		t.Fatal("expected non-nil body after deanonymize")
+	}
+	_, _ = io.ReadAll(resp.Body)
+}
+
+// --- E) Handler-path branches ---
+
+// fakeConnHijacker is an http.Hijacker whose Hijack() always returns an error.
+type fakeConnHijacker struct {
+	*httptest.ResponseRecorder
+}
+
+func newFakeConnHijacker() *fakeConnHijacker {
+	return &fakeConnHijacker{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (fakeConnHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, errors.New("hijack failed")
+}
+
+// newCATestServer builds a Server with a real MITM CA and the given AI domain.
+func newCATestServer(t *testing.T, aiDomain string) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "ca-cert.pem")
+	keyFile := filepath.Join(dir, "ca-key.pem")
+	cfg := &config.Config{
+		OllamaEndpoint: "http://localhost:11434",
+		OllamaModel:    "test",
+		AIAPIDomains:   []string{aiDomain},
+		EnabledPacks:   []string{"GLOBAL"},
+		CACertFile:     certFile,
+		CAKeyFile:      keyFile,
+	}
+	domains := management.NewDomainRegistry(cfg, "")
+	srv := New(cfg, domains, metrics.New())
+	t.Cleanup(func() { _ = srv.Close() })
+	if srv.ca == nil {
+		t.Fatal("expected CA to be loaded")
+	}
+	return srv
+}
+
+// handleTunnel MITM branch: routes to handleMITMTunnel, which (with a non-hijacker
+// writer) falls back to handleOpaqueTunnel. Use a dialContext that returns quickly.
+func TestHandleTunnel_MITMBranch(t *testing.T) {
+	srv := newCATestServer(t, "api.example.com")
+	// Make the opaque fallback dial fail fast instead of hanging on the network.
+	srv.dialContext = func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("dial blocked")
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect,
+		"http://api.example.com:443", nil)
+	req.Host = "api.example.com:443"
+	req.RemoteAddr = "127.0.0.1:5555"
+
+	// httptest.NewRecorder is NOT an http.Hijacker -> MITM falls back to opaque,
+	// which dials (fails fast) and returns 502.
+	w := httptest.NewRecorder()
+	srv.handleTunnel(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 from opaque fallback dial failure, got %d", w.Code)
+	}
+}
+
+// handleMITMTunnel Hijack error branch.
+func TestHandleMITMTunnel_HijackError(t *testing.T) {
+	srv := newCATestServer(t, "api.example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect,
+		"http://api.example.com:443", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+
+	w := newFakeConnHijacker()
+	srv.handleMITMTunnel(w, req, "api.example.com:443", "api.example.com")
+
+	// WriteHeader(200) is called before Hijack(); after Hijack errors it returns.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 written before hijack, got %d", w.Code)
+	}
+}
+
+// handleMITMTunnel happy-hijack path that returns: a successful Hijack hands back
+// a conn whose peer is closed, so mitm.HandleConn fails the TLS handshake and
+// returns promptly, letting handleMITMTunnel return and fire its deferred
+// clientConn.Close().
+func TestHandleMITMTunnel_HandshakeFailReturns(t *testing.T) {
+	srv := newCATestServer(t, "api.example.com")
+
+	client, server := net.Pipe()
+	// Close the client side so the server-side TLS handshake gets EOF immediately.
+	_ = client.Close()
+
+	hw := &pipeHijacker{ResponseRecorder: httptest.NewRecorder(), conn: server}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect,
+		"http://api.example.com:443", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+
+	// Returns once HandleConn's handshake fails; the deferred clientConn.Close runs.
+	srv.handleMITMTunnel(hw, req, "api.example.com:443", "api.example.com")
+
+	if hw.Code != http.StatusOK {
+		t.Fatalf("expected 200 written before hijack, got %d", hw.Code)
+	}
+}
+
+// pipeHijacker is an http.Hijacker that returns a preset net.Conn.
+type pipeHijacker struct {
+	*httptest.ResponseRecorder
+	conn net.Conn
+}
+
+func (h *pipeHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReader(h.conn), bufio.NewWriter(h.conn))
+	return h.conn, rw, nil
+}
+
+// serveMITMRequest !ok branch: oversized body -> processMITMRequestBody returns
+// ("", false) -> 413 and no forwarding.
+func TestServeMITMRequest_ProcessBodyError(t *testing.T) {
+	srv := newTestProxyServer(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST",
+		"https://api.example.com/v1/chat", nil)
+	req.Body = infiniteReader{}
+	req.ContentLength = maxRequestBody + 10
+
+	rw := newResponseRecorder()
+	ctx := mitmContext{host: "api.example.com:443", domain: "api.example.com", remoteHash: "abcd1234"}
+
+	srv.serveMITMRequest(rw, req, ctx)
+
+	if rw.code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rw.code)
+	}
+}
+
+// handleOpaqueTunnel: dial succeeds (fake conn) but writer is not a Hijacker.
+func TestHandleOpaqueTunnel_HijackNotSupported(t *testing.T) {
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+	srv.dialContext = func(context.Context, string, string) (net.Conn, error) {
+		return server, nil
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect,
+		"http://example.com:443", nil)
+	req.Host = "example.com:443"
+	req.RemoteAddr = "127.0.0.1:5555"
+
+	// httptest.NewRecorder is not a Hijacker.
+	w := httptest.NewRecorder()
+	srv.handleOpaqueTunnel(w, req, "example.com:443")
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 hijacking not supported, got %d", w.Code)
+	}
+}
+
+// handleOpaqueTunnel: dial succeeds but Hijack() errors.
+func TestHandleOpaqueTunnel_HijackError(t *testing.T) {
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+	srv.dialContext = func(context.Context, string, string) (net.Conn, error) {
+		return server, nil
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodConnect,
+		"http://example.com:443", nil)
+	req.Host = "example.com:443"
+	req.RemoteAddr = "127.0.0.1:5555"
+
+	w := newFakeConnHijacker()
+	srv.handleOpaqueTunnel(w, req, "example.com:443")
+
+	// WriteHeader(200) is sent before Hijack(); Hijack errors then returns.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 written before hijack, got %d", w.Code)
+	}
+}
+
+// handleHTTP ANON path: AI domain, non-auth, body with synthetic PII produces a
+// non-empty sessionID and exercises the [ANON] log + DeleteSession defer.
+func TestHandleHTTP_AnonPath(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer backend.Close()
+
+	host := backendHostPort(t, backend.URL, "http")
+	// handleHTTP matches on the port-stripped host ("localhost"), so register
+	// the bare domain (not the host:port form) for the AI-anonymize path.
+	srv := newTestProxyServerAllowLocal(t, []string{"localhost"}, nil)
+
+	body := `{"prompt":"contact alice@example.com please"}`
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://"+host+"/v1/x",
+		strings.NewReader(body))
+	req.Host = host
+	req.URL.Host = host
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+
+	w := httptest.NewRecorder()
+	srv.handleHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// forward URL.Host fallback + private-host block.
+func TestForward_URLHostFallbackPrivate(t *testing.T) {
+	srv := newTestProxyServerAllowLocal(t, nil, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "http://placeholder/test", nil)
+	req.URL.Host = ""     // forces fallback to r.Host
+	req.Host = "10.0.0.1" // private -> 403 before any dial
+
+	w := httptest.NewRecorder()
+	srv.forward(w, req, "", "domain")
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for private fallback host, got %d", w.Code)
+	}
+}

--- a/internal/proxy/proxy_coverage_test.go
+++ b/internal/proxy/proxy_coverage_test.go
@@ -9,8 +9,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"ai-anonymizing-proxy/internal/config"
 	"ai-anonymizing-proxy/internal/management"
@@ -149,11 +151,17 @@ func TestAnonymizeRequestBody_RandFallback(t *testing.T) {
 	if sessionID == "" {
 		t.Fatal("expected non-empty timestamp-fallback sessionID")
 	}
-	// Fallback is a UnixNano integer string: all digits.
-	for _, c := range sessionID {
-		if c < '0' || c > '9' {
-			t.Fatalf("expected all-digit fallback sessionID, got %q", sessionID)
-		}
+	// The success path is exactly 16 hex chars from rand.Read; the fallback is
+	// fmt.Sprintf("%d", time.Now().UnixNano()). Prove the fallback was taken by
+	// requiring a base-10 integer in a recent-nanosecond range — a 16-char hex
+	// token cannot satisfy this (max all-digit hex value ~1e16 < the bound).
+	n, parseErr := strconv.ParseInt(sessionID, 10, 64)
+	if parseErr != nil {
+		t.Fatalf("expected UnixNano timestamp fallback sessionID, got %q (parse err: %v)", sessionID, parseErr)
+	}
+	const year2020Nanos = 1_600_000_000_000_000_000
+	if n < year2020Nanos {
+		t.Fatalf("expected a recent UnixNano timestamp fallback, got %q (%d)", sessionID, n)
 	}
 	srv.anon.DeleteSession(sessionID)
 }
@@ -364,8 +372,14 @@ func TestHandleOpaqueTunnel_HijackError(t *testing.T) {
 // handleHTTP ANON path: AI domain, non-auth, body with synthetic PII produces a
 // non-empty sessionID and exercises the [ANON] log + DeleteSession defer.
 func TestHandleHTTP_AnonPath(t *testing.T) {
+	// Capture the body the upstream actually receives so we can prove the [ANON]
+	// path ran (PII replaced before forwarding), not merely that a 200 came back
+	// — a plain passthrough would also return 200. The buffered channel gives a
+	// happens-before edge for the race detector.
+	gotBody := make(chan string, 1)
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
+		gotBody <- string(b)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"ok":true}`))
@@ -377,7 +391,8 @@ func TestHandleHTTP_AnonPath(t *testing.T) {
 	// the bare domain (not the host:port form) for the AI-anonymize path.
 	srv := newTestProxyServerAllowLocal(t, []string{"localhost"}, nil)
 
-	body := `{"prompt":"contact alice@example.com please"}`
+	const pii = "alice@example.com"
+	body := `{"prompt":"contact ` + pii + ` please"}`
 	req := httptest.NewRequestWithContext(context.Background(), "POST", "http://"+host+"/v1/x",
 		strings.NewReader(body))
 	req.Host = host
@@ -390,6 +405,20 @@ func TestHandleHTTP_AnonPath(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case received := <-gotBody:
+		// The ANON path must have rewritten the synthetic PII into a token before
+		// forwarding upstream.
+		if strings.Contains(received, pii) {
+			t.Errorf("upstream received un-anonymized PII; body was forwarded as passthrough: %s", received)
+		}
+		if !strings.Contains(received, "[PII_") {
+			t.Errorf("expected an anonymized [PII_...] token in the forwarded body, got: %s", received)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream never received the forwarded request")
 	}
 }
 

--- a/internal/proxy/proxy_coverage_test.go
+++ b/internal/proxy/proxy_coverage_test.go
@@ -2,12 +2,15 @@ package proxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -18,6 +21,16 @@ import (
 	"ai-anonymizing-proxy/internal/management"
 	"ai-anonymizing-proxy/internal/metrics"
 )
+
+// captureLog redirects the standard logger to a buffer so a branch's
+// distinctive log line can be asserted. These tests are not parallel.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return &buf
+}
 
 // --- A) mustParsePrivateNetworks ---
 
@@ -46,13 +59,24 @@ func TestSsrfSafeDialContext_Branches(t *testing.T) {
 	dialFn := ssrfSafeDialContext(&net.Dialer{})
 
 	t.Run("split host port error falls to direct dial", func(t *testing.T) {
-		// No colon -> net.SplitHostPort fails -> d.DialContext path.
-		// Use a canceled context so the dial returns immediately.
+		// No colon -> net.SplitHostPort fails -> the direct d.DialContext path,
+		// which must NOT consult the resolver. Pin that branch: fail loudly if
+		// lookup is reached (it would be, if the SplitHostPort-error fallback
+		// were removed and control fell through to the lookup path).
+		lookupReached := false
+		lookupIPAddr = func(context.Context, string) ([]net.IPAddr, error) {
+			lookupReached = true
+			return nil, errors.New("resolver must not be reached on the direct-dial path")
+		}
+		// Canceled context so the direct dial returns immediately.
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		_, err := dialFn(ctx, "tcp", "hostwithoutport")
 		if err == nil {
 			t.Fatal("expected error from direct dial of invalid address")
+		}
+		if lookupReached {
+			t.Error("SplitHostPort-error path must dial directly without resolving")
 		}
 	})
 
@@ -251,8 +275,17 @@ func TestHandleTunnel_MITMBranch(t *testing.T) {
 	// httptest.NewRecorder is NOT an http.Hijacker -> MITM falls back to opaque,
 	// which dials (fails fast) and returns 502.
 	w := httptest.NewRecorder()
+	logs := captureLog(t)
 	srv.handleTunnel(w, req)
 
+	// Branch-specific evidence that handleTunnel selected the MITM path: only
+	// handleMITMTunnel logs "[MITM] ... Intercepting CONNECT" (at its top, before
+	// the hijacker fallback). If the AI-domain branch were removed, the request
+	// would route straight to handleOpaqueTunnel — same 502, but no MITM log — so
+	// asserting the status alone does not prove MITM routing for this privacy path.
+	if !strings.Contains(logs.String(), "Intercepting CONNECT api.example.com:443") {
+		t.Errorf("expected handleTunnel to route the AI domain into MITM (Intercepting CONNECT log), got: %q", logs.String())
+	}
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502 from opaque fallback dial failure, got %d", w.Code)
 	}
@@ -295,18 +328,35 @@ func TestHandleMITMTunnel_HandshakeFailReturns(t *testing.T) {
 	// Returns once HandleConn's handshake fails; the deferred clientConn.Close runs.
 	srv.handleMITMTunnel(hw, req, "api.example.com:443", "api.example.com")
 
-	if hw.Code != http.StatusOK {
-		t.Fatalf("expected 200 written before hijack, got %d", hw.Code)
+	// Pin the success path. A recorder defaults Code to 200, so assert
+	// wroteHeader (not just Code) to prove WriteHeader(200) actually ran, and
+	// assert the hijack was taken — the handshake-fail-returns flow only runs
+	// after a successful Hijack.
+	if !hw.wroteHeader || hw.Code != http.StatusOK {
+		t.Fatalf("expected WriteHeader(200) before hijack (wrote=%v code=%d)", hw.wroteHeader, hw.Code)
+	}
+	if !hw.hijackCalled {
+		t.Fatal("expected handleMITMTunnel to hijack the connection on the MITM path")
 	}
 }
 
-// pipeHijacker is an http.Hijacker that returns a preset net.Conn.
+// pipeHijacker is an http.Hijacker that returns a preset net.Conn and records
+// whether WriteHeader and Hijack were invoked (a bare ResponseRecorder defaults
+// Code to 200, so wroteHeader is needed to actually pin the WriteHeader call).
 type pipeHijacker struct {
 	*httptest.ResponseRecorder
-	conn net.Conn
+	conn         net.Conn
+	wroteHeader  bool
+	hijackCalled bool
+}
+
+func (h *pipeHijacker) WriteHeader(code int) {
+	h.wroteHeader = true
+	h.ResponseRecorder.WriteHeader(code)
 }
 
 func (h *pipeHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijackCalled = true
 	rw := bufio.NewReadWriter(bufio.NewReader(h.conn), bufio.NewWriter(h.conn))
 	return h.conn, rw, nil
 }
@@ -441,8 +491,16 @@ func TestForward_URLHostFallbackPrivate(t *testing.T) {
 	req.Host = "10.0.0.1" // private -> 403 before any dial
 
 	w := httptest.NewRecorder()
+	logs := captureLog(t)
 	srv.forward(w, req, "", "domain")
 
+	// Pin the private-block branch by its distinctive log line, which also proves
+	// the URL.Host fallback ran (it logs the filled-in r.URL.Host = "10.0.0.1").
+	// Asserting the 403 alone is environment-coupled: an outbound proxy can also
+	// return 403 for a private dial even if this block branch were removed.
+	if !strings.Contains(logs.String(), "Blocked request to private address: 10.0.0.1") {
+		t.Errorf("expected private-address block log for the fallback host, got: %q", logs.String())
+	}
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for private fallback host, got %d", w.Code)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1386,7 +1386,7 @@ func TestHandleMITMTunnel(t *testing.T) {
 	defer func() { _ = srv.Close() }()
 
 	// Override transport to trust the backend's TLS cert
-	srv.transport = backend.Client().Transport.(*http.Transport) //nolint:errcheck // test setup
+	srv.transport, _ = backend.Client().Transport.(*http.Transport) // test setup
 
 	if srv.ca == nil {
 		t.Fatal("expected CA to be loaded")


### PR DESCRIPTION
# Pull Request

## What

Removes every `//nolint:errcheck` directive in the codebase (33 production + 52 test = 85 total) and replaces each with explicit error handling (`c2eebb0`). Because removing the directives marks seven source files as &#34;changed&#34;, their functions are pulled into the CI function-level delta-coverage gate (95%). Several pre-existing defensive error branches were previously unreachable by tests, so follow-up commits add focused tests plus minimal, idiomatic **seams** (test-only fault injection / observability) that keep the existing error handling intact and make it genuinely testable — no `//nolint`, no `t.Skip`, no `// coverage-ignore`, no gate suppression. A toolchain bump clears two stdlib CVEs; five rounds of maintainer review and exhaustive mutation self-audits are incorporated. Every error-path/branch test is **mutation-verified** (deleting/altering its target branch makes the test fail).

## Changes

- **Error-handling fix (`c2eebb0`):** framework `pw.Write` chains → `writePipe` helper; `CloseWithError` checked + logged; best-effort closes → `defer func() { _ = x.Close() }()` / `_ = x.Close()`; `io.Copy`/`dst.Write` → `_, _ = …`; dead nolints removed.
- **Coverage seams + tests (`af7b7be`):** `jsonMarshal`, `bboltBucket` (const→var), `pipeWriter` interface, `jsonMarshalIndent` + `createPersistTempFile`, `rsaGenerateKey`/`randInt`/`x509CreateCertificate`, `lookupIPAddr`, `randRead`; `init()` → unit-testable `mustParsePrivateNetworks`; removed an unreachable, redundant dead branch in `validDomain`. Each seam leaves the production path identical (the package var equals the real stdlib function) and exists only so a test can exercise or observe a pre-existing error branch.
- **Toolchain (`767478e`):** `go.mod` `go 1.26.3` → `1.26.4` — patch-only. Clears `GO-2026-5039` / `GO-2026-5037`.
- **Portable PEM-write tests (`c8a8f0a`):** `/dev/full` → `pemEncode = pem.Encode` seam.
- **Branch-pinning + de-flake (`24eabf8`, `dce1ee1`, `060e98e`, `05d44a4`):** anonymized-body / UnixNano-fallback assertions; `handleStreamEnd` flush + `CloseWithError` + EOF-skip; bad-gzip readable; `persist`/`bbolt`/`writeJSON` log assertions; async dispatch tests use a deterministic `waitUntil` poll.
- **Branch-pinning rounds 2–4 (`0e52c7f`, `76bd2d3`, `5891fdd`):** strengthened the remaining coverage tests to assert each branch&#39;s distinctive log line, recorded flag, or observable effect — MITM routing log; forward private-block log; closed-db `Get` log; persist rename log; loadPacks warning log; MITM/opaque/handshake hijack tests via `wroteHeader`/`hijackCalled`; and a `dialContextFn` seam over `(*net.Dialer).DialContext` so the SSRF tests assert the **dial target** (direct-dial path uses the raw addr; post-resolution dial targets the inspected IP `8.8.8.8:443`, not the hostname), plus the `decompression error` log. All mutation-verified, including against the specific wrong-implementations review named.

All seams are behavior-neutral (production paths use the real functions); no production behavior changes.

## Quality Gates

- [x] `make check` passed locally (lint + test + security + vulncheck, all exit 0). Last line: **`All checks passed.`** (go1.26-rebuilt linters — see toolchain note)
- [x] `go test -race ./...` passed (deterministic across repeated runs; former-flaky async tests de-flaked)
- [x] Coverage minimums met: `internal/anonymizer` 97.2%, `internal/anonymizer/packs` 97.6%, `internal/config` 100% (≥95% gate); **overall 98.3%** (≥ 85% gate)
- [x] Delta coverage passes at the CI threshold (**95.0%**) on all changed files — see [Delta Coverage Report](#delta-coverage-report)
- [x] [§6 Test Inventory baseline-vs-head](#6-test-inventory--baseline-vs-head) executed on `main` and on head `5891fdd`
- [x] No hacks — no new `//nolint`, no `t.Skip()`, no `// coverage-ignore`, no hardcoded-to-pass assertions, no new `gosec` exclusions; `grep -rn &#34;nolint:errcheck&#34;` empty; tests are portable and each error-path test asserts (and is **mutation-verified** to require) the specific branch effect it names
- [x] All CI jobs green at head `5891fdd` — Test, Lint, Security Scan, Build (amd64/arm64/macOS), MSI, CodeQL, Analyze, Benchmark, and 6 install round-trips all ✅; sign/publish skipped (release-only)


&gt; **Toolchain note.** The bundled `golangci-lint` is built against go1.25 and refuses to analyze this go1.26 module, so `make check` was run with go1.26-rebuilt tools (golangci-lint v2.10.1, gosec, govulncheck) on PATH — final line `All checks passed.`. `govulncheck` reports 0 vulnerabilities affecting this code under go1.26.4. The async `TestDispatchOllamaAsyncWithMockServer` is de-flaked (`060e98e`); the gate passes deterministically across repeated runs.

## Out-of-scope follow-up

An adversarial review pass surfaced a **pre-existing** flaky test unrelated to this change: a TOCTOU port race in the `freePort` `cmd/proxy` test helper that intermittently fails `TestMain_HelperProcess_Lifecycle` under heavy ephemeral-port contention. It exists on `main`, is **not** in this PR&#39;s changed files, and is tracked separately in **#140**.

## Delta Coverage Report

**Command:**

```bash
go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
bash .github/scripts/delta-coverage.sh coverage.out 95.0 origin/main
```

**Raw script output:**

```text
=== Delta Coverage Check (threshold: 95.0%) ===

Changed source files:
  internal/anonymizer/anonymizer.go
  internal/anonymizer/cache.go
  internal/anonymizer/streaming.go
  internal/management/management.go
  internal/mitm/cert.go
  internal/mitm/mitm.go
  internal/proxy/proxy.go

Checked 96 functions in 7 changed files.
SUCCESS: All functions in changed files meet 95.0% coverage threshold.
```

**Per-function table** — every function in the 7 changed source files (96 total) is at **100.0%** (24 were below 95% before this PR: loadPacks 86.7, AnonymizeJSON 94.4, newBboltCache 80.0, bboltCache Get/Set/Delete 76.9/66.7/66.7, writePipe 66.7, handleStreamEnd 85.7, persist 44.0, validDomain 94.9, writeJSON 75.0, ListenAndServe 0.0, LoadOrGenerateCA 88.9, LoadCA 84.0, GenerateCA 80.0, CertFor 81.2, init→mustParsePrivateNetworks 80.0, ssrfSafeDialContext 71.4, handleTunnel 75.0, handleMITMTunnel 83.3, serveMITMRequest 90.9, handleOpaqueTunnel 87.9, handleHTTP 89.7, anonymizeRequestBody 90.9 — all now 100%). Full per-function listing is unchanged from the prior revision (all 96 at 100%).

## §6 Test Inventory — baseline vs head

Method (template §6): `git checkout `, then `go test -race -count=1 -v `, counting `--- PASS` / `--- FAIL` (top-level + subtests). Executed on `main` (`6140e58`) **and** on head `5891fdd`.

| Package | main (`6140e58`) PASS / FAIL | head (`5891fdd`) PASS / FAIL | Delta |
|---|---|---|---|
| `./cmd/proxy/` | 34 / 0 | 34 / 0 | 0 |
| `./internal/anonymizer/` | 385 / 0 | 393 / 0 | +8 PASS |
| `./internal/anonymizer/packs/` | 177 / 0 | 177 / 0 | 0 |
| `./internal/config/` | 39 / 0 | 39 / 0 | 0 |
| `./internal/domainmatch/` | 44 / 0 | 44 / 0 | 0 |
| `./internal/envfile/` | 12 / 0 | 12 / 0 | 0 |
| `./internal/logger/` | 15 / 0 | 15 / 0 | 0 |
| `./internal/management/` | 52 / 0 | 61 / 0 | +9 PASS |
| `./internal/metrics/` | 17 / 0 | 17 / 0 | 0 |
| `./internal/mitm/` | 30 / 0 | 43 / 0 | +13 PASS |
| `./internal/proxy/` | 103 / 0 | 122 / 0 | +19 PASS |
| **TOTAL** | **908 / 0** | **957 / 0** | **+49 PASS** |

Zero failures on either side, across repeated runs. (A separate pre-existing `cmd/proxy` helper flake — `freePort`/`TestMain_HelperProcess_Lifecycle` — reproduces only under artificial multi-process contention and is tracked in #140.)

## Test Plan

New tests genuinely exercise and **assert** each branch&#39;s distinctive effect — every error-path/branch test is mutation-verified (altering its target branch makes the test fail), including against the specific wrong-implementations raised in review:

- `streaming_error_test.go` — `handleStreamEnd` partial-line flush + `CloseWithError`-once-with-read-error + inner failure log (EOF path asserts no close); `writePipe` early-return write-count.
- `cache_error_test.go` — bucket-creation error; nil-bucket Get/Set(log)/Delete(no-op); closed-db Get(log)/Delete(log).
- `persist_error_test.go` — marshal / create-temp / write(log) / close(log) / rename(log); `writeJSON` encode error(log); `ListenAndServe` bind error.
- `cert_error_test.go` — crypto seam errors in `GenerateCA`/`CertFor`; portable PEM-write errors; `LoadCA` non-RSA key; `LoadOrGenerateCA` failures.
- `proxy_coverage_test.go` — `mustParsePrivateNetworks` panic; `ssrfSafeDialContext` branches incl. direct-dial **dials raw addr** and final dial **targets the inspected IP** (`8.8.8.8:443`); body-too-large + rand fallback; bad-gzip decompression **error-log**; `handleTunnel` MITM routing(log); MITM hijack-error/handshake-fail and opaque hijack-error (wroteHeader/hijackCalled); `serveMITMRequest` 413; opaque hijack-not-supported; `handleHTTP` ANON (forwarded body anonymized); `forward` URL.Host fallback + private block(log).
- `anonymizer_test.go` — async dispatch tests use a deterministic real-time `waitUntil` poll.

## Linked Issues

Closes #102
Follow-up (out of scope): #140